### PR TITLE
docs: Close issue #19 - Symlinks fix validation

### DIFF
--- a/ISSUES_FIXED.md
+++ b/ISSUES_FIXED.md
@@ -1,0 +1,3 @@
+# Issue #19 Fix Validated
+
+Symlinks are now properly created during setup. ✅


### PR DESCRIPTION
Closes #19: Symlinks not created during setup

The fix from PR #33 has been validated. The setup script now properly replaces existing directories with symlinks.

Closes #19