### PR TITLE
feat: Add CLAUDE.md generation during setup (#20)

### DIFF
--- a/template/.setup/setup.sh
+++ b/template/.setup/setup.sh
@@ -42,7 +42,8 @@ WHAT THIS SCRIPT DOES:
     3. ✅ Creates GitHub labels (type:*, priority:*, status:*)
     4. ✅ Creates GitHub Project v2 board
     5. ✅ Links workflows and issue templates
-    6. ✅ Saves setup state for idempotent reruns
+    5.5. ✅ Copies CLAUDE.md to project root
+    6. ✅ Finalizes setup and saves state for idempotent reruns
 
 PREREQUISITES:
     - GitHub CLI (gh) installed and authenticated
@@ -126,6 +127,7 @@ main() {
         "3-init-labels"
         "4-create-project"
         "5-link-workflows"
+        "5.5-copy-claude-md"
         "6-finalize"
     )
 

--- a/template/.setup/steps/5.5-copy-claude-md.sh
+++ b/template/.setup/steps/5.5-copy-claude-md.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Step 5.5: Copy CLAUDE.md to project root
+
+SETUP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+source "${SETUP_DIR}/lib/colors.sh"
+source "${SETUP_DIR}/lib/state.sh"
+
+run_step() {
+    section "Step 5.5/6: Copying CLAUDE.md to Project Root"
+
+    # Get paths
+    local TEMPLATE_CLAUDE="${SETUP_DIR}/../claude.md"
+    local PROJECT_CLAUDE="${PWD}/CLAUDE.md"
+
+    # Check if source file exists
+    if [ ! -f "$TEMPLATE_CLAUDE" ]; then
+        warning "Source CLAUDE.md not found at $TEMPLATE_CLAUDE"
+        warning "Skipping CLAUDE.md copy step"
+        mark_step_completed "copy_claude_md"
+        return 0
+    fi
+
+    # Check if CLAUDE.md already exists in project root
+    if [ -f "$PROJECT_CLAUDE" ]; then
+        # Check if it's the same file or a customized version
+        if diff -q "$TEMPLATE_CLAUDE" "$PROJECT_CLAUDE" > /dev/null 2>&1; then
+            success "CLAUDE.md already copied (identical)"
+        else
+            info "CLAUDE.md exists but appears customized"
+            info "Not overwriting custom version"
+        fi
+    else
+        # Copy CLAUDE.md to project root
+        cp "$TEMPLATE_CLAUDE" "$PROJECT_CLAUDE"
+        success "Copied CLAUDE.md to project root"
+        info "Documentation available at: ./CLAUDE.md"
+    fi
+
+    mark_step_completed "copy_claude_md"
+    return 0
+}
+
+# Run if called directly
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    run_step
+    exit $?
+fi

--- a/template/.setup/steps/6-finalize.sh
+++ b/template/.setup/steps/6-finalize.sh
@@ -34,6 +34,7 @@ run_step() {
     echo "  ✅ GitHub Project v2 board"
     echo "  ✅ Workflows linked (create-branch, code-review, etc.)"
     echo "  ✅ Issue templates linked"
+    echo "  ✅ CLAUDE.md copied to project root"
     echo ""
     highlight "Project: $REPO_OWNER/$REPO_NAME"
     echo ""


### PR DESCRIPTION
## Summary
Implements automatic CLAUDE.md copying during the setup process.

## Issue
Closes #20

## Changes
- Created new step 5.5 (`5.5-copy-claude-md.sh`) to copy CLAUDE.md from template root to project
- Integrated step into setup orchestrator
- Added skip logic if CLAUDE.md already exists (idempotent)
- Updated setup summary to mention CLAUDE.md in the completion message

## Implementation Details
- Step checks if source CLAUDE.md exists
- If destination already exists, compares with source to detect customizations
- Skips overwriting if file appears to have been customized
- Marks step as completed for idempotent reruns
- Follows existing setup script patterns and conventions

## Testing
- Step file is executable
- Integrated into setup flow between step 5 and step 6
- State tracking ensures idempotent behavior
- Help text updated to document new step

## Checklist
- [x] Code follows project conventions
- [x] Step is idempotent and skips if already done
- [x] Help text updated
- [x] Integrated into setup flow
- [x] Issue #20 properly referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)