### PR TITLE
chore(us-75): Remove unused anthropic/openai dependencies (#75)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@
 python-dotenv==1.0.0
 requests==2.31.0
 
-# LLM & API clients
-anthropic==0.40.0
-openai==1.33.0
+# LLM API client (Gemini only)
 google-generativeai==0.6.0
 
 # GitHub interaction


### PR DESCRIPTION
## Summary

- Removed `anthropic==0.40.0` and `openai==1.33.0` from `requirements.txt`
- Updated comment to reflect Gemini-only setup
- Kept `google-generativeai==0.6.0` as the sole LLM dependency

Closes #75

## Verification

Searched all Python files under the repository for `import anthropic`, `import openai`, `from anthropic`, and `from openai` — **no active imports found**. These dependencies were unused dead weight after the Gemini migration in PR #72.