### PR TITLE
feat(us-77): Auto-add new issues to project board (#77)

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,29 @@
+name: Auto-add issues to project board
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: read
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add issue to project (official action)
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/dyvan/projects/3
+          github-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Fallback - Add issue via gh CLI
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+          echo "Primary action failed, attempting fallback with gh CLI..."
+          gh project item-add 3 --owner dyvan --url "$ISSUE_URL"
+          echo "Issue added to project via gh CLI fallback"

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -129,9 +129,17 @@ jobs:
             --base "$BASE_BRANCH" \
             --head "$BRANCH_NAME" || echo "⚠️  Could not create PR (might already exist)"
 
-      # NOTE: Issues are NOT automatically added to project on creation.
-      # They remain in GitHub Backlog until manually moved or auto-branch label is added.
-      # See WORKFLOW_SPECIFICATION.md for details.
+      - name: Add issue to project on creation
+        continue-on-error: true
+        if: github.event_name == 'issues' && github.event.action == 'opened'
+        env:
+          GH_TOKEN: ${{ env.GH_TOKEN }}
+        run: |
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+          ISSUE_NUM=${{ github.event.issue.number }}
+          echo "Adding issue #$ISSUE_NUM to project board..."
+          gh project item-add $PROJECT_NUM --owner $GH_OWNER --url "$ISSUE_URL"
+          echo "Issue #$ISSUE_NUM added to project board"
 
       - name: Update project on issue labeled
         continue-on-error: true


### PR DESCRIPTION
## Summary

Closes #77

Automatically adds newly created issues to the GitHub Projects v2 board (project #3) so they appear in Backlog without manual intervention.

## Approach

Two complementary mechanisms ensure issues are always added to the project:

1. **Dedicated workflow (`auto-add-to-project.yml`)** - A standalone workflow triggered on `issues: [opened]` that uses the official `actions/add-to-project@v1.0.2` GitHub action. If the action fails, a fallback step uses `gh project item-add` via the CLI.

2. **Integrated step in `update-project.yml`** - A new step "Add issue to project on creation" runs on `issues.opened` events within the existing project sync workflow, using `gh project item-add` with the dynamically loaded project number. This replaces the previous comment block (lines 132-134) that noted issues were NOT auto-added.

Both approaches use `secrets.GH_TOKEN` for authentication (requires `project` scope).

## Changes Made

- Added `.github/workflows/auto-add-to-project.yml` (new dedicated workflow)
- Updated `.github/workflows/update-project.yml` (replaced NOTE comment with active step)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or sensitive data committed
- [x] Issue referenced (`Closes #77`)