### PR TITLE
fix(us-74): Fix GH_TOKEN scope for Projects v2 GraphQL (#74)

### DIFF
--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -1,5 +1,25 @@
 name: Update GitHub Project
 
+# =============================================================================
+# REQUIRED TOKEN SCOPES
+# =============================================================================
+# This workflow uses GitHub's GraphQL API to manage Projects v2 boards.
+# The default GITHUB_TOKEN does NOT support Projects v2 operations.
+#
+# You MUST create a Personal Access Token (classic) with these scopes:
+#   - repo        (full control of private repositories)
+#   - project     (full control of projects -- REQUIRED for Projects v2 GraphQL)
+#   - workflow    (update GitHub Action workflows)
+#
+# Then store it as a repository secret named GH_TOKEN:
+#   gh secret set GH_TOKEN
+#
+# Without the 'project' scope, all project board updates will fail with
+# HTTP 401 or "Resource not accessible by integration" errors.
+#
+# See: docs/Configuration.md for detailed setup instructions.
+# =============================================================================
+
 on:
   push:
     branches: [main, develop, staging, 'feat/*', 'fix/*', 'refactor/*', 'docs/*']
@@ -12,10 +32,9 @@ permissions:
   contents: read
   issues: read
   pull-requests: write  # Required to create PRs automatically
-  # Projects v2 requires write permission to modify custom fields
+  # Projects v2 requires a PAT with 'project' scope -- the built-in
+  # GITHUB_TOKEN cannot access Projects v2 GraphQL mutations.
   # See: https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue
-  # Note: GITHUB_TOKEN may not have sufficient permissions for Projects v2.
-  # If this fails, you may need to use a Personal Access Token with 'project' scope.
 
 jobs:
   update-project:
@@ -38,12 +57,59 @@ jobs:
           if [ -n "${{ secrets.GH_TOKEN }}" ]; then
             echo "GH_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
             echo "has_project_token=true" >> $GITHUB_OUTPUT
-            echo "✅ Using custom GH_TOKEN with project permissions"
+            echo "Using custom GH_TOKEN"
           else
             echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
             echo "has_project_token=false" >> $GITHUB_OUTPUT
-            echo "⚠️  Using default GITHUB_TOKEN (may lack project permissions)"
+            echo "::warning::No GH_TOKEN secret found. Using default GITHUB_TOKEN which lacks 'project' scope. Project board updates will fail. See docs/Configuration.md for setup instructions."
           fi
+
+      - name: Diagnose token permissions for Projects v2
+        id: diagnose
+        run: |
+          echo "--- Token Diagnostics ---"
+
+          # Test 1: Basic GraphQL connectivity
+          HTTP_CODE=$(curl -s -o /tmp/graphql_response.json -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"query":"query { viewer { login } }"}' \
+            https://api.github.com/graphql)
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            VIEWER=$(cat /tmp/graphql_response.json | python3 -c "import sys,json; print(json.load(sys.stdin).get('data',{}).get('viewer',{}).get('login','unknown'))" 2>/dev/null || echo "unknown")
+            echo "GraphQL auth OK (authenticated as: $VIEWER)"
+          else
+            echo "::error::GraphQL authentication failed (HTTP $HTTP_CODE). Check that GH_TOKEN is valid."
+            echo "has_project_scope=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Test 2: Projects v2 scope -- try to list projects for the repo owner
+          HTTP_CODE=$(curl -s -o /tmp/project_response.json -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\":\"query { user(login: \\\"$GH_OWNER\\\") { projectsV2(first: 1) { totalCount } } }\"}" \
+            https://api.github.com/graphql)
+
+          RESPONSE=$(cat /tmp/project_response.json)
+          HAS_ERRORS=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if 'errors' in d else 'no')" 2>/dev/null || echo "unknown")
+
+          if [ "$HTTP_CODE" = "200" ] && [ "$HAS_ERRORS" = "no" ]; then
+            PROJECT_COUNT=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['user']['projectsV2']['totalCount'])" 2>/dev/null || echo "?")
+            echo "Projects v2 access OK (found $PROJECT_COUNT project(s) for $GH_OWNER)"
+            echo "has_project_scope=true" >> $GITHUB_OUTPUT
+          else
+            ERROR_MSG=$(echo "$RESPONSE" | python3 -c "import sys,json; errs=json.load(sys.stdin).get('errors',[]); print(errs[0].get('message','unknown') if errs else 'unknown')" 2>/dev/null || echo "unknown")
+            echo "::warning::Projects v2 access FAILED: $ERROR_MSG"
+            echo "::warning::Your GH_TOKEN is missing the 'project' scope. Project board updates will be skipped."
+            echo "::warning::Fix: Create a new PAT at https://github.com/settings/tokens/new with scopes: repo, project, workflow"
+            echo "::warning::Then run: gh secret set GH_TOKEN"
+            echo "::warning::See docs/Configuration.md for detailed instructions."
+            echo "has_project_scope=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "--- End Diagnostics ---"
 
       - name: Load project configuration
         id: config
@@ -217,5 +283,12 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "✅ Project synchronization workflow completed"
-          echo "GitHub Projects v2 board updated via GraphQL API"
+          echo "--- Update Project Workflow Summary ---"
+          if [ "${{ steps.diagnose.outputs.has_project_scope }}" = "true" ]; then
+            echo "Token: OK (has project scope)"
+          else
+            echo "Token: MISSING project scope -- project board steps were skipped or failed"
+            echo "Action required: See docs/Configuration.md for GH_TOKEN setup"
+          fi
+          echo "Event: ${{ github.event_name }} / ${{ github.event.action }}"
+          echo "--- End Summary ---"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,14 +1,83 @@
-# ⚙️ Configuration
+# Configuration
 
-Comment personnaliser le template selon vos besoins.
+How to customize the template for your needs.
 
-## Fichier de configuration principal
+## GitHub Token (GH_TOKEN) -- REQUIRED for Projects v2
+
+The `update-project.yml` workflow uses GitHub's GraphQL API to automatically
+sync issues and PRs with your Projects v2 board. This requires a Personal
+Access Token (PAT) with the **`project` scope**, which the default
+`GITHUB_TOKEN` does **not** provide.
+
+### Why the default GITHUB_TOKEN is not enough
+
+GitHub Actions provides an automatic `GITHUB_TOKEN` for each workflow run.
+However, this token does **not** include the `project` scope needed for
+Projects v2 GraphQL mutations (`addProjectV2ItemById`,
+`updateProjectV2ItemFieldValue`, etc.). Attempting to use it will result in:
+
+- HTTP 401 errors
+- `"Resource not accessible by integration"` GraphQL errors
+- Silent failures with `continue-on-error: true`
+
+### Creating a Personal Access Token
+
+1. Go to **https://github.com/settings/tokens/new** (classic token)
+2. Give it a descriptive name, e.g. `project-bot-token`
+3. Set an expiration (recommended: 90 days, then rotate)
+4. Select the following scopes:
+
+| Scope       | Why it is needed |
+|-------------|-----------------|
+| `repo`      | Read/write access to repository contents, issues, and PRs |
+| `project`   | Read/write access to Projects v2 (GraphQL API) |
+| `workflow`  | Allows the token to trigger and update GitHub Actions workflows |
+
+5. Click **Generate token** and copy the value immediately.
+
+### Adding the token as a repository secret
+
+```bash
+# Using GitHub CLI (recommended)
+gh secret set GH_TOKEN
+# Paste the token when prompted
+
+# Or via the GitHub web UI:
+# Settings > Secrets and variables > Actions > New repository secret
+# Name: GH_TOKEN
+# Value: <your token>
+```
+
+### Verifying the token works
+
+After setting the secret, you can verify it by triggering the
+`update-project.yml` workflow. Check the **"Diagnose token permissions for
+Projects v2"** step in the workflow logs. You should see:
+
+```
+GraphQL auth OK (authenticated as: your-username)
+Projects v2 access OK (found N project(s) for your-username)
+```
+
+If you see warnings about missing `project` scope, regenerate the token
+with the correct scopes.
+
+### Fine-Grained Personal Access Tokens
+
+Fine-grained PATs do not currently support Projects v2 GraphQL operations.
+You must use a **classic** PAT. See the
+[GitHub docs on token types](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+for details.
+
+---
+
+## Project configuration file
 
 ### `.github/project.yml`
 
 ```yaml
 project:
-  number: 1  # 👈 Changez selon votre projet
+  number: 1  # Change to match your project number
   name: "Project Backlog"
   auto_link: true
 
@@ -21,56 +90,54 @@ fields:
     default: "Medium"
 ```
 
-**À modifier** :
-- `project.number` : Mettez le numéro de votre projet GitHub
+**To modify**:
+- `project.number`: Set to the number of your GitHub Project (visible in the project URL)
 
-## Labels GitHub
+## GitHub Labels
 
-Les labels sont créés par `setup-project.sh`. Pour les personnaliser :
+Labels are created by `setup-project.sh`. To customize:
 
 ```bash
-# Modifier setup-project.sh ligne 86+
+# Edit setup-project.sh labels section
 declare -a LABELS=(
     "type:feature:0e8a16:New feature"
-    "priority:urgent:ff0000:Urgent"  # Ajoutez vos labels
+    "priority:urgent:ff0000:Urgent"  # Add your labels
 )
 ```
 
-## Secrets GitHub
+## Other Secrets
 
-### Requis
-- `GH_TOKEN` : Token avec scopes `repo`, `project`, `workflow`
+### Required
+- `GH_TOKEN`: PAT with scopes `repo`, `project`, `workflow` (see above)
 
-### Optionnels
-- `CLAUDE_API_KEY` : Pour revue de code IA
+### Optional
+- `GEMINI_API_KEY`: Google Gemini API key (used by code review, planning, and spec workflows)
+- `GEMINI_PLAN_API_KEY`: Dedicated key for plan-with-gemini workflow (falls back to GEMINI_API_KEY)
+- `GEMINI_SPEC_API_KEY`: Dedicated key for generate-specification workflow (falls back to GEMINI_API_KEY)
+- `GEMINI_REVIEW_API_KEY`: Dedicated key for code-review-agent workflow (falls back to GEMINI_API_KEY)
+- `SLACK_WEBHOOK_URL`: For Slack notifications
 
 ```bash
 gh secret set GH_TOKEN
-gh secret set CLAUDE_API_KEY
+gh secret set GEMINI_API_KEY
 ```
 
 ## Workflows
 
-Modifiez les workflows dans `.github/workflows/` selon vos besoins :
+Modify workflows in `.github/workflows/` as needed:
 
-### Changer le modèle Claude
-Dans `code-review-agent.yml` ligne 69 :
-```python
-model="claude-3-5-sonnet-20241022"  # Changez ici
+### Change branch naming convention
+In `create-branch.yml`:
+```bash
+BRANCH_NAME="feat/${ISSUE_NUMBER}-${SLUGIFIED}"  # Customize
 ```
 
-### Modifier le naming des branches
-Dans `create-branch.yml` ligne 32 :
+### Add fields to the Project Board
+In `update-project.yml`, add your label mappings:
 ```bash
-BRANCH_NAME="feat/${ISSUE_NUMBER}-${SLUGIFIED}"  # Personnalisez
-```
-
-### Ajouter des champs au Project Board
-Dans `update-project.yml`, ajoutez vos mappings :
-```bash
-if [[ "$LABEL" == "mon-label" ]]; then
-  python scripts/project_sync.py --issue $ISSUE_NUM --status "Mon Status"
+if [[ "$LABEL" == "my-label" ]]; then
+  python scripts/project_sync.py --issue $ISSUE_NUM --status "My Status"
 fi
 ```
 
-[⬅️ Getting Started](Getting-Started) | [➡️ Using The Template](Using-The-Template)
+[<- Getting Started](Getting-Started) | [-> Using The Template](Using-The-Template)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -18,20 +18,36 @@ sudo apt install gh
 winget install GitHub.cli
 ```
 
-## "Project not found" ou "GraphQL errors"
+## "Project not found" or "GraphQL errors" or HTTP 401
 
-**Causes** :
-- Projet n'existe pas
-- Mauvais numéro dans `.github/project.yml`
-- Token sans scope `project`
+**Most common cause**: The `GH_TOKEN` secret is missing the `project` scope.
 
-**Solutions** :
+The default `GITHUB_TOKEN` provided by GitHub Actions does **not** support
+Projects v2 GraphQL operations. You need a classic Personal Access Token (PAT)
+with scopes: `repo`, `project`, `workflow`.
+
+**How to fix**:
+
+1. Create a new PAT at https://github.com/settings/tokens/new
+2. Select scopes: `repo`, `project`, `workflow`
+3. Save it as a repository secret:
+   ```bash
+   gh secret set GH_TOKEN
+   ```
+4. Re-run the failed workflow
+
+See [Configuration](Configuration) for detailed instructions.
+
+**Other causes**:
+- Project does not exist or wrong number in `.github/project.yml`
+- Fine-grained PAT used instead of classic PAT (Projects v2 requires classic)
+
 ```bash
-# Vérifier projets existants
+# Verify existing projects
 gh project list --owner YOUR_USERNAME
 
-# Mettre à jour project.yml avec bon numéro
-# Recréer token avec scope project
+# Check the diagnostic step in update-project.yml workflow logs
+# for detailed error messages
 ```
 
 ## "Permission denied" sur scripts
@@ -95,13 +111,16 @@ pytest tests/ -v
 python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/ci-tests.yml']]"
 ```
 
-## Token GitHub invalide
+## Invalid or insufficient GitHub token
 
-**Recréer** :
-1. Aller sur https://github.com/settings/tokens/new
-2. Cocher scopes : `repo`, `project`, `workflow`
-3. Générer
-4. Configurer : `gh secret set GH_TOKEN`
+**Recreate**:
+1. Go to https://github.com/settings/tokens/new (must be **classic** token)
+2. Select scopes: `repo`, `project`, `workflow`
+3. Generate and copy the token
+4. Store as secret: `gh secret set GH_TOKEN`
+
+**Note**: Fine-grained PATs do not support Projects v2. Use a classic PAT.
+See [Configuration](Configuration) for details.
 
 ## Besoin d'aide supplémentaire
 


### PR DESCRIPTION
## Summary
- Added comprehensive token scope documentation to `update-project.yml` workflow header
- Added a **diagnostic step** that probes GraphQL auth and `project` scope before any sync runs, surfacing actionable `::warning::` annotations in CI logs
- Rewrote `docs/Configuration.md` with step-by-step PAT creation instructions (scopes, classic vs fine-grained, verification)
- Updated `docs/Troubleshooting.md` with clearer Projects v2 error guidance
- Kept `continue-on-error: true` as safety net on project sync steps

Closes #74

## Test plan
- [ ] Push to branch triggers `update-project.yml` -- verify the "Diagnose token permissions" step runs and outputs correct status
- [ ] With a valid GH_TOKEN (repo+project+workflow scopes): diagnostic reports OK, project sync steps succeed
- [ ] Without GH_TOKEN secret: diagnostic emits `::warning::` annotations visible in Actions UI
- [ ] With a token missing `project` scope: diagnostic detects the missing scope and warns