### PR TITLE
docs(us-76): Update documentation post-Gemini migration (#76)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -99,8 +99,8 @@ automation:
 agents:
   code_review:
     enabled: true
-    provider: "claude"  # Options: claude, openai, gemini
-    model: "claude-3-5-sonnet-20241022"
+    provider: "gemini"
+    model: "gemini-2.0-flash"
     on_events:
       - "pull_request.opened"
       - "pull_request.synchronize"

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -266,7 +266,7 @@ jobs:
           pip install -r requirements-dev.txt
 
           # Check critical imports
-          python -c "import requests; import yaml; import anthropic"
+          python -c "import requests; import yaml; import google.generativeai"
 
           deactivate
           rm -rf /tmp/test-venv

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -58,7 +58,7 @@ gh pr merge 45
 ### 3. **Code Review by AI** ✅
 **Trigger**: PR opened, synchronized, or reopened
 **What happens**:
-- Claude AI analyzes the diff
+- Gemini AI analyzes the diff
 - Posts structured comment with:
   - ✅ Strengths
   - ⚠️ Suggestions
@@ -66,7 +66,7 @@ gh pr merge 45
 
 **Workflow**: `.github/workflows/code-review-agent.yml`
 
-**Requirements**: `CLAUDE_API_KEY` secret configured
+**Requirements**: `GEMINI_API_KEY` secret configured (or `GEMINI_REVIEW_API_KEY`)
 
 ---
 
@@ -125,8 +125,7 @@ gh pr merge 45
 **Manual setup required**:
 ```bash
 gh secret set GH_TOKEN
-gh secret set CLAUDE_API_KEY
-gh secret set OPENAI_API_KEY  # Optional
+gh secret set GEMINI_API_KEY
 ```
 
 **Why manual?**: Security - secrets cannot be auto-configured
@@ -158,7 +157,7 @@ Use this checklist when setting up a new project from this template:
 - [ ] **3. Configure GitHub Secrets**
   ```bash
   gh secret set GH_TOKEN          # GitHub Personal Access Token
-  gh secret set CLAUDE_API_KEY    # Anthropic API key
+  gh secret set GEMINI_API_KEY    # Google Gemini API key
   ```
 
 - [ ] **4. Manually configure Project Board custom fields**
@@ -369,7 +368,7 @@ python scripts/project_sync.py --issue 123 --status "In Progress"
 ### Code review not working?
 
 **Check**:
-1. Is `CLAUDE_API_KEY` secret configured?
+1. Is `GEMINI_API_KEY` secret configured?
 2. Check workflow logs: Actions → Code Review Agent
 
 **Fallback**: Script provides basic review without API key

--- a/CLAUDE-USER-TEMPLATE.md
+++ b/CLAUDE-USER-TEMPLATE.md
@@ -421,7 +421,7 @@ gh auth status
 
 # Variables disponibles dans workflows
 echo $GH_TOKEN         # GitHub Token
-echo $CLAUDE_API_KEY   # Pour AI review (optionnel)
+echo $GEMINI_API_KEY   # Pour AI review (optionnel)
 ```
 
 ### .env (gitignored)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ EOF
 
 # 3. Informer l'utilisateur
 echo "✅ PR créée et prête pour review"
-echo "🤖 Le Code Review Agent (Claude) va analyser automatiquement"
+echo "🤖 Le Code Review Agent (Gemini) va analyser automatiquement"
 echo "🧪 Les tests CI/CD vont se lancer automatiquement"
 ```
 
@@ -297,7 +297,7 @@ python scripts/generate_dashboard.py
 
 ### 2. `code-review-agent.yml`
 **Déclencheur** : PR ouverte, synchronisée, ou rouverte
-**Action** : Claude AI analyse le code et poste un commentaire avec :
+**Action** : Gemini AI analyse le code et poste un commentaire avec :
   - ✅ Points positifs
   - ⚠️ Suggestions d'amélioration
   - 🔴 Problèmes critiques (sécurité, performance)
@@ -700,10 +700,13 @@ python scripts/project_sync.py --issue 156 --status "In Review"
 Dans **Settings → Secrets and variables → Actions** :
 
 - `GH_TOKEN` : GitHub Personal Access Token (scopes: `repo`, `workflow`, `read:org`)
-- `CLAUDE_API_KEY` : Anthropic API key pour le code review
-- `OPENAI_API_KEY` : (Optionnel) OpenAI API key
-- `GEMINI_API_KEY` : (Optionnel) Google Gemini API key
+- `GEMINI_API_KEY` : Google Gemini API key pour le code review et les workflows IA
+- `GEMINI_PLAN_API_KEY` : (Optionnel) Clé Gemini dédiée au workflow de planification
+- `GEMINI_SPEC_API_KEY` : (Optionnel) Clé Gemini dédiée au workflow de spécification
+- `GEMINI_REVIEW_API_KEY` : (Optionnel) Clé Gemini dédiée au workflow de code review
 - `SLACK_WEBHOOK_URL` : (Optionnel) Pour notifications Slack
+
+> **Note** : Les clés par workflow (`GEMINI_PLAN_API_KEY`, `GEMINI_SPEC_API_KEY`, `GEMINI_REVIEW_API_KEY`) sont optionnelles. Si elles ne sont pas configurées, `GEMINI_API_KEY` est utilisée comme fallback.
 
 ### Variables d'Environnement
 
@@ -713,9 +716,7 @@ Fichier `.env` (local uniquement, jamais committer) :
 GH_TOKEN=ghp_xxxxxxxxxxxxx
 GH_OWNER=your-username
 GH_REPO=your-repo-name
-CLAUDE_API_KEY=sk-ant-xxxxxxxxxxxxx
-LLM_PROVIDER=claude
-LLM_MODEL=claude-3-5-sonnet-20241022
+GEMINI_API_KEY=AIza-xxxxxxxxxxxxx
 DEBUG=false
 LOG_LEVEL=INFO
 ```
@@ -728,7 +729,7 @@ LOG_LEVEL=INFO
 - **GitHub Projects v2** : https://docs.github.com/en/issues/planning-and-tracking-with-projects
 - **GitHub Actions** : https://docs.github.com/en/actions
 - **Conventional Commits** : https://www.conventionalcommits.org/
-- **Anthropic Claude API** : https://docs.anthropic.com/
+- **Google Gemini API** : https://aistudio.google.com/
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,9 +137,7 @@ project-name/
 - **GitHub Actions** : CI/CD
 
 ### APIs LLM
-- **Claude (Anthropic)** : Code review, suggestions
-- **OpenAI API** : Alternative (optionnel)
-- **Gemini API** : Alternative (optionnel)
+- **Gemini (Google)** : Code review, planification, spécification
 
 ---
 

--- a/agents/code_reviewer.md
+++ b/agents/code_reviewer.md
@@ -42,8 +42,8 @@ Récupère les changements complets de la PR (limité à 10000 lignes)
 - Diff : (voir fichier temporaire)
 ```
 
-#### Étape 3 : Appel à l'API Claude
-Envoie au modèle `claude-3-5-sonnet-20241022` :
+#### Étape 3 : Appel à l'API Gemini
+Envoie au modèle `gemini-2.0-flash` :
 
 ```
 Prompt:
@@ -64,7 +64,7 @@ Provide a code review with:
 ```
 
 #### Étape 4 : Génération de la revue
-Claude retourne une réponse structurée en Markdown
+Gemini retourne une réponse structurée en Markdown
 
 #### Étape 5 : Publication en tant que commentaire PR
 ```bash
@@ -74,7 +74,7 @@ gh pr comment {PR_NUMBER} --body "{review_comment}"
 ### 3. **Format de la réponse**
 
 ```markdown
-## 🤖 Automated Code Review by Claude AI
+## 🤖 Automated Code Review by Gemini AI
 
 ### ✅ Strengths
 - Good error handling in the database query
@@ -105,7 +105,7 @@ gh pr comment {PR_NUMBER} --body "{review_comment}"
 ## 🔑 Configuration
 
 ### Secrets requis
-- `CLAUDE_API_KEY` : Clé API Anthropic
+- `GEMINI_API_KEY` : Clé API Google Gemini (ou `GEMINI_REVIEW_API_KEY` pour une clé dédiée)
 
 ### Fichier de workflow
 `.github/workflows/code-review-agent.yml`
@@ -114,13 +114,13 @@ gh pr comment {PR_NUMBER} --body "{review_comment}"
 
 | Propriété | Valeur |
 |-----------|--------|
-| **Provider** | Anthropic |
-| **Model** | `claude-3-5-sonnet-20241022` |
+| **Provider** | Google Gemini |
+| **Model** | `gemini-2.0-flash` |
 | **Max Tokens** | 1024 |
 | **Temperature** | 1.0 (défaut) |
 
 ### Alternative : Fallback sans API key
-Si `CLAUDE_API_KEY` n'est pas défini, l'agent fourni une revue de base :
+Si `GEMINI_API_KEY` n'est pas défini, l'agent fourni une revue de base :
 - Check de taille de fichiers
 - Vérification de commits
 - Rappel de configuration de clé API
@@ -241,9 +241,9 @@ Merge + Project Board update
 
 Avant d'activer le Code Reviewer :
 
-- [ ] Ajouter `CLAUDE_API_KEY` à GitHub Secrets
+- [ ] Ajouter `GEMINI_API_KEY` à GitHub Secrets
 - [ ] Tester sur une PR pilote
-- [ ] Vérifier le coût API (Anthropic billing)
+- [ ] Vérifier le coût API (Google AI Studio billing)
 - [ ] Définir les rules de code review team
 - [ ] Former les developers à utiliser le feedback
 - [ ] Itérer sur les prompts pour améliorer qualité

--- a/docs/Advanced-Customization.md
+++ b/docs/Advanced-Customization.md
@@ -60,17 +60,7 @@ Configurez le même `GH_PROJECT_NUMBER` dans chaque repo.
 
 ## Changer le modèle LLM
 
-Dans `code-review-agent.yml` :
-
-```python
-# Utiliser GPT-4
-from openai import OpenAI
-client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
-response = client.chat.completions.create(
-    model="gpt-4-turbo",
-    messages=[{"role": "user", "content": prompt}]
-)
-```
+Tous les workflows IA utilisent Gemini. Le modèle par défaut est `gemini-2.0-flash`. Pour changer le modèle, modifiez la variable correspondante dans le workflow `code-review-agent.yml`.
 
 ## Ajouter des validations custom
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -126,6 +126,9 @@ gh secret set GEMINI_API_KEY
 
 Modify workflows in `.github/workflows/` as needed:
 
+### Change the Gemini model
+The default model is `gemini-2.0-flash`. You can change it in the workflow environment variables.
+
 ### Change branch naming convention
 In `create-branch.yml`:
 ```bash

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -109,12 +109,12 @@ gh auth login
 gh secret set GH_TOKEN
 # Collez votre token quand demandé
 
-# (Optionnel) Configurez la clé API Claude pour la revue de code IA
-gh secret set CLAUDE_API_KEY
-# Obtenez votre clé sur : https://console.anthropic.com/
+# (Optionnel) Configurez la clé API Gemini pour la revue de code IA
+gh secret set GEMINI_API_KEY
+# Obtenez votre clé sur : https://aistudio.google.com/app/apikey
 ```
 
-> **💡 Note** : Sans `CLAUDE_API_KEY`, la revue de code fonctionnera en mode basique (sans IA).
+> **💡 Note** : Sans `GEMINI_API_KEY`, la revue de code fonctionnera en mode basique (sans IA).
 
 ---
 

--- a/docs/Scripts-Reference.md
+++ b/docs/Scripts-Reference.md
@@ -106,7 +106,7 @@ python3 scripts/setup_project_fields.py \
 1. ✅ **Prérequis** : gh, python3, git installés
 2. ✅ **Repository** : Dans un repo git avec remote GitHub
 3. ✅ **Authentification** : GitHub CLI authentifié
-4. ✅ **Secrets** : GH_TOKEN et CLAUDE_API_KEY configurés
+4. ✅ **Secrets** : GH_TOKEN et GEMINI_API_KEY configurés
 5. ✅ **Labels** : Tous les labels requis existent
 6. ✅ **Project** : Au moins un projet existe
 7. ✅ **Workflows** : Tous les workflows sont présents
@@ -276,9 +276,9 @@ git checkout feat/42-add-dark-mode
 4. Poste la revue en commentaire
 
 **Mode fallback** :
-Si `CLAUDE_API_KEY` n'est pas configuré, fonctionne en mode basique (checklist manuelle).
+Si `GEMINI_API_KEY` n'est pas configuré, fonctionne en mode basique (checklist manuelle).
 
-**Modèle utilisé** : `claude-3-5-sonnet-20241022`
+**Modèle utilisé** : `gemini-2.0-flash`
 
 ---
 

--- a/docs/Template-Validation.md
+++ b/docs/Template-Validation.md
@@ -103,7 +103,7 @@ Le workflow `.github/workflows/template-validation.yml` valide automatiquement q
 **Packages testés** :
 - requests
 - pyyaml
-- anthropic
+- google-generativeai
 - pytest
 - pytest-cov
 - pytest-mock

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -91,12 +91,12 @@ python3 scripts/project_sync.py --issue 1 --status "Backlog"
 ## Code Review ne fonctionne pas
 
 **Sans commentaire** :
-- Vérifier `CLAUDE_API_KEY` : `gh secret list`
+- Vérifier `GEMINI_API_KEY` : `gh secret list`
 - Mode basique sans API key
 
 **Erreur API** :
 - Vérifier validité clé
-- Vérifier quotas : https://console.anthropic.com/
+- Vérifier quotas : https://aistudio.google.com/
 
 ## Tests échouent
 

--- a/docs/Understanding-Workflows.md
+++ b/docs/Understanding-Workflows.md
@@ -54,11 +54,11 @@ env:
 
 **Actions** :
 1. Récupère le diff
-2. Envoie à Claude AI
+2. Envoie à Gemini AI
 3. Génère revue (Points forts, Suggestions, Problèmes)
 4. Poste commentaire
 
-**Mode fallback** : Sans CLAUDE_API_KEY, checklist basique
+**Mode fallback** : Sans GEMINI_API_KEY, checklist basique
 
 ### 4. ci-tests.yml
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -177,7 +177,7 @@ Deploy to production
 ## 🔌 Integration Points
 
 ### External Services
-- **Claude API** (Anthropic) : Code review
+- **Gemini API** (Google) : Code review
 - **GitHub API** : Repository operations
 - **GitHub GraphQL** : Project updates (future)
 

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -224,9 +224,9 @@ on:
 ```
 
 ### Requirements
-- `CLAUDE_API_KEY` secret configured
+- `GEMINI_API_KEY` secret configured (or `GEMINI_REVIEW_API_KEY`)
 - PR should be < 10000 lines (limit)
-- Python with anthropic library installed
+- Python with google-generativeai library installed
 
 ### Process
 
@@ -237,7 +237,7 @@ Get PR diff (via gh cli)
      ↓
 Prepare prompt with diff + PR description
      ↓
-Call Claude API with prompt
+Call Gemini API with prompt
      ↓
 Parse response (structured markdown)
      ↓
@@ -264,19 +264,17 @@ Provide review with:
 3. 🔴 Critical Issues
 ```
 
-### Claude Configuration
+### Gemini Configuration
 ```python
-client = Anthropic()
-response = client.messages.create(
-    model="claude-3-5-sonnet-20241022",
-    max_tokens=1024,
-    messages=[{"role": "user", "content": prompt}]
-)
+import google.generativeai as genai
+genai.configure(api_key=os.getenv('GEMINI_API_KEY'))
+model = genai.GenerativeModel('gemini-2.0-flash')
+response = model.generate_content(prompt)
 ```
 
 ### Example Output
 ```markdown
-## 🤖 Automated Code Review by Claude AI
+## 🤖 Automated Code Review by Gemini AI
 
 ### ✅ Strengths
 - Good separation of concerns
@@ -302,9 +300,7 @@ response = client.messages.create(
 
 #### Change Model
 ```python
-model="claude-3-sonnet-20240229",  # Other Claude versions
-# or
-model="gpt-4",  # OpenAI fallback
+model = genai.GenerativeModel('gemini-1.5-pro')  # Other Gemini models
 ```
 
 #### Increase/Decrease Detail
@@ -326,11 +322,11 @@ prompt = f"""Review focusing on:
 ```
 
 ### Fallback Behavior
-If `CLAUDE_API_KEY` not set:
+If `GEMINI_API_KEY` not set:
 ```
 ⚠️ Code review workflow encountered an error
 
-Add CLAUDE_API_KEY to GitHub Secrets to enable full AI-powered review.
+Add GEMINI_API_KEY to GitHub Secrets to enable full AI-powered review.
 ```
 
 ---
@@ -514,14 +510,15 @@ Then:
 
 ### Secrets for Workflows
 Add/update in **Settings → Secrets and variables → Actions**:
-- `CLAUDE_API_KEY` : Anthropic API key
-- `OPENAI_API_KEY` : OpenAI API key (optional)
-- `GEMINI_API_KEY` : Google Gemini API key (optional)
+- `GEMINI_API_KEY` : Google Gemini API key (required for AI features)
+- `GEMINI_REVIEW_API_KEY` : Dedicated key for code review (optional, falls back to GEMINI_API_KEY)
+- `GEMINI_PLAN_API_KEY` : Dedicated key for planning (optional, falls back to GEMINI_API_KEY)
+- `GEMINI_SPEC_API_KEY` : Dedicated key for specification (optional, falls back to GEMINI_API_KEY)
 
 Access in workflows:
 ```yaml
 env:
-  CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 ```
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,8 +22,8 @@ Environ 5 minutes en suivant le guide.
 gh issue create --title "Ma tâche" --label "type:feature,auto-branch"
 ```
 
-### Puis-je désactiver Claude AI ?
-Oui, ne configurez simplement pas `CLAUDE_API_KEY`. La revue fonctionnera en mode basique.
+### Puis-je désactiver l'IA Gemini ?
+Oui, ne configurez simplement pas `GEMINI_API_KEY`. La revue fonctionnera en mode basique.
 
 ### Comment personnaliser les labels ?
 Éditez `setup-project.sh` lignes 86+ et relancez le script.
@@ -33,11 +33,11 @@ Oui, complètement.
 
 ## Techniques
 
-### Quel modèle Claude est utilisé ?
-`claude-3-5-sonnet-20241022` par défaut. Modifiable dans `code-review-agent.yml`.
+### Quel modèle est utilisé ?
+`gemini-2.0-flash` par défaut. Modifiable dans les variables des workflows.
 
 ### Puis-je utiliser un autre LLM ?
-Oui ! Remplacez l'appel API dans `code-review-agent.yml` par OpenAI, Gemini, etc.
+Actuellement, tous les workflows utilisent Gemini. Pour utiliser un autre provider, il faut modifier les workflows manuellement.
 
 ### Les workflows consomment-ils beaucoup de minutes GitHub Actions ?
 Non, très peu. Environ 1-2 minutes par workflow.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,24 +50,29 @@ gh auth login
 # Authenticate with browser
 ```
 
-#### `CLAUDE_API_KEY` (for Code Review)
-1. Get your API key from [console.anthropic.com](https://console.anthropic.com)
+#### `GEMINI_API_KEY` (for Code Review and AI workflows)
+1. Get your API key from [aistudio.google.com](https://aistudio.google.com/app/apikey)
 2. Add it to your repo secrets:
 
 ```bash
-gh secret set CLAUDE_API_KEY --body "sk-ant-..."
-```
-
-### Optional Secrets
-
-#### `OPENAI_API_KEY` (Alternative to Claude)
-```bash
-gh secret set OPENAI_API_KEY --body "sk-..."
-```
-
-#### `GEMINI_API_KEY` (Alternative to Claude)
-```bash
 gh secret set GEMINI_API_KEY --body "AIza..."
+```
+
+### Optional Secrets (per-workflow keys)
+
+#### `GEMINI_REVIEW_API_KEY` (dedicated key for code review)
+```bash
+gh secret set GEMINI_REVIEW_API_KEY --body "AIza..."
+```
+
+#### `GEMINI_PLAN_API_KEY` (dedicated key for planning)
+```bash
+gh secret set GEMINI_PLAN_API_KEY --body "AIza..."
+```
+
+#### `GEMINI_SPEC_API_KEY` (dedicated key for specification)
+```bash
+gh secret set GEMINI_SPEC_API_KEY --body "AIza..."
 ```
 
 ## Step 4: Enable GitHub Projects v2
@@ -199,7 +204,7 @@ Run this checklist:
 **Solution**: Check **Settings → Actions → General** → ensure workflows are enabled
 
 ### Issue: Code Review Agent not working
-**Solution**: Verify `CLAUDE_API_KEY` is set correctly (no extra spaces)
+**Solution**: Verify `GEMINI_API_KEY` is set correctly (no extra spaces)
 
 ### Issue: Branch not created
 **Solution**: Ensure `auto-branch` label is added to the issue

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ This is a comprehensive, production-ready template for managing software project
 
 ### Integration
 - Seamless GitHub Projects v2 integration
-- Multiple LLM provider support (Anthropic Claude, OpenAI, Google Gemini)
+- Google Gemini AI integration for code review, planning, and specification
 - Full CI/CD pipeline with automatic status updates
 
 ## 🚀 Quick Start
@@ -43,7 +43,7 @@ cd project-llm-management
 
 ### 3. Configure GitHub Secrets
 Go to **Settings → Secrets and variables → Actions** and add:
-- `CLAUDE_API_KEY` (for code review)
+- `GEMINI_API_KEY` (for code review)
 - `GH_TOKEN` (GitHub token with repo access)
 
 ### 4. Enable GitHub Projects v2
@@ -71,7 +71,7 @@ graph TD
     A["Create Issue<br/>+ auto-branch label"] -->|GitHub Actions| B["Branch Creator<br/>Creates feat/123-title"]
     B --> C["Develop Locally"]
     C --> D["Push & Create PR"]
-    D -->|GitHub Actions| E["Code Reviewer<br/>Claude analyzes code"]
+    D -->|GitHub Actions| E["Code Reviewer<br/>Gemini analyzes code"]
     D -->|GitHub Actions| F["CI Tests<br/>Run tests & lint"]
     E --> G["Post Comments"]
     F --> H["Report Results"]
@@ -110,7 +110,7 @@ Filter by assignee and sprint for personal tracking
 ### API Keys
 All sensitive credentials stored in GitHub Secrets (never in git):
 ```
-GH_TOKEN, CLAUDE_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
+GH_TOKEN, GEMINI_API_KEY
 ```
 
 ## 🎓 Use Cases

--- a/install.sh
+++ b/install.sh
@@ -298,8 +298,8 @@ GH_PROJECT_NUMBER=0
 GEMINI_API_KEY=$gemini_key
 
 # LLM Configuration
-LLM_PROVIDER=claude
-LLM_MODEL=claude-3-5-sonnet-20241022
+LLM_PROVIDER=gemini
+LLM_MODEL=gemini-2.0-flash
 
 # Logging
 LOG_LEVEL=INFO

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -182,8 +182,8 @@ GH_PROJECT_NUMBER=${gh_project_number:-0}
 GEMINI_API_KEY=$gemini_key
 
 # LLM Configuration
-LLM_PROVIDER=claude
-LLM_MODEL=claude-3-5-sonnet-20241022
+LLM_PROVIDER=gemini
+LLM_MODEL=gemini-2.0-flash
 
 # Logging
 LOG_LEVEL=INFO

--- a/scripts/validate_setup.sh
+++ b/scripts/validate_setup.sh
@@ -95,10 +95,10 @@ if [ -n "$REPO_OWNER" ] && [ -n "$REPO_NAME" ]; then
         WARNINGS=$((WARNINGS + 1))
     fi
 
-    if echo "$SECRETS" | grep -q "CLAUDE_API_KEY"; then
-        echo "  ✅ CLAUDE_API_KEY configured"
+    if echo "$SECRETS" | grep -q "GEMINI_API_KEY"; then
+        echo "  ✅ GEMINI_API_KEY configured"
     else
-        echo -e "  ${YELLOW}⚠️  CLAUDE_API_KEY secret not configured${NC}"
+        echo -e "  ${YELLOW}⚠️  GEMINI_API_KEY secret not configured${NC}"
         echo "     Code review agent will run in basic mode"
         WARNINGS=$((WARNINGS + 1))
     fi

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -92,11 +92,11 @@ echo ""
 echo -e "${BLUE}Step 1/5: Checking GitHub Secrets...${NC}"
 echo "Required secrets:"
 echo "  - GH_TOKEN: GitHub Personal Access Token"
-echo "  - CLAUDE_API_KEY: Anthropic Claude API key (for code review)"
+echo "  - GEMINI_API_KEY: Google Gemini API key (for code review)"
 echo ""
 echo "To add secrets, run:"
 echo "  gh secret set GH_TOKEN"
-echo "  gh secret set CLAUDE_API_KEY"
+echo "  gh secret set GEMINI_API_KEY"
 echo ""
 read -p "Have you configured the required secrets? (y/n) " -n 1 -r
 echo

--- a/template-setup.sh
+++ b/template-setup.sh
@@ -31,7 +31,7 @@ QUICK START (3 steps):
 
   2. Edit .env with your settings:
      - GH_TOKEN: Your GitHub Personal Access Token
-     - CLAUDE_API_KEY: Your Anthropic Claude API key (optional)
+     - GEMINI_API_KEY: Your Google Gemini API key (optional)
 
   3. Run setup:
      bash template-setup.sh

--- a/template/.setup/steps/6-finalize.sh
+++ b/template/.setup/steps/6-finalize.sh
@@ -57,7 +57,7 @@ run_step() {
     echo ""
     echo "4. Add GitHub secrets (if using CI/CD):"
     echo "   gh secret set GH_TOKEN"
-    echo "   gh secret set CLAUDE_API_KEY"
+    echo "   gh secret set GEMINI_API_KEY"
     echo ""
 
     return 0


### PR DESCRIPTION
## Summary
- Replace all `CLAUDE_API_KEY` and `OPENAI_API_KEY` references with `GEMINI_API_KEY` across documentation
- Document per-workflow keys (`GEMINI_PLAN_API_KEY`, `GEMINI_SPEC_API_KEY`, `GEMINI_REVIEW_API_KEY`) with fallback to `GEMINI_API_KEY`
- Update LLM_PROVIDER/LLM_MODEL from claude to gemini in bootstrap.sh and install.sh
- Remove anthropic and openai from requirements.txt (only google-generativeai remains)
- Update code examples, FAQ, troubleshooting, and architecture docs to reference Gemini
- Update .github/project.yml agent config to use gemini provider
- Update template-validation.yml to import google.generativeai instead of anthropic

Closes #76

## Test plan
- [ ] Verify no remaining references to CLAUDE_API_KEY, OPENAI_API_KEY, anthropic, or openai in docs
- [ ] Verify install.sh and bootstrap.sh generate correct .env with Gemini config
- [ ] Verify template-validation workflow imports correct library