### PR TITLE
docs: Add landing page and fix MkDocs nav (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ site/
 # NOTE: Only ignore the state file, not the setup scripts!
 template/.setup/.setup-state.json
 .setup-state.json
+site/

--- a/docs/getting-started/first-issue.md
+++ b/docs/getting-started/first-issue.md
@@ -224,6 +224,6 @@ You just:
 
 ## 🎓 Next Steps
 
-- Explore the [LLM agents](../guides/using-agents.md)
-- Set up [Slack webhooks](../guides/setup-github-projects.md)
+- Learn about [Advanced Customization](../Advanced-Customization.md)
+- Configure [GitHub Projects v2](../architecture/github-projects.md)
 - Customize the [workflows](../architecture/workflows.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -216,8 +216,8 @@ Run this checklist:
 
 1. ✅ [Quick Start Guide](./quickstart.md) - Run your first workflow
 2. 📚 [Architecture Overview](../architecture/overview.md) - Understand the system
-3. 📝 [Contributing Guide](../../CONTRIBUTING.md) - Start contributing
+3. 📝 [Contributing Guide](../Contributing.md) - Start contributing
 
 ---
 
-Need help? Check the [FAQ](../faq.md) or [Troubleshooting Guide](../guides/troubleshooting.md)
+Need help? Check the [FAQ](../faq.md) or [Troubleshooting Guide](../Troubleshooting.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -263,8 +263,8 @@ Project Updated
 ## 📚 What's Next?
 
 - [Architecture Guide](../architecture/overview.md) - Learn how it works
-- [Using Agents](../guides/using-agents.md) - Advanced agent configuration
-- [Contributing](../../CONTRIBUTING.md) - Start contributing to projects
+- [Advanced Customization](../Advanced-Customization.md) - Customize the template
+- [Contributing](../Contributing.md) - Start contributing to projects
 - [FAQ](../faq.md) - Common questions and answers
 
 ## 💡 Tips

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,150 +1,262 @@
-# Project LLM Management
-
-Welcome to the **GitHub-based Project Management with LLM Agents** template!
-
-This is a comprehensive, production-ready template for managing software projects using:
-
-- 🏗️ **GitHub Projects v2** for centralized tracking
-- 🤖 **LLM Agents** (Gemini, Claude, ChatGPT) for automation
-- 🔄 **GitHub Actions** for CI/CD and workflows
-- 👥 **Human oversight** via a central Project Board
-
-## 🎯 Key Features
-
-### Automated Workflows
-- **QCM Generator**: Gemini-powered questionnaires to clarify specifications before implementation
-- **Branch Creator**: Automatically creates feature branches when issues receive the `auto-branch` label
-- **Code Reviewer**: AI-powered code reviews on pull requests
-- **Test Feedback**: Automated testing, linting, and coverage reporting
-
-### Project Management
-- **Backlog View**: All future work, sorted by priority
-- **Priority Board**: Kanban-style tracking by status
-- **Team Items**: Personalized view filtered by owner
-
-### Integration
-- Seamless GitHub Projects v2 integration
-- Google Gemini AI integration for code review, planning, and specification
-- Full CI/CD pipeline with automatic status updates
-
-## 🚀 Quick Start
-
-### 1. Prerequisites
-- Git
-- GitHub account with admin access
-- GitHub CLI (`gh`)
-- Python 3.11+ (if using Python workflows)
-
-### 2. Clone/Fork this template
-```bash
-git clone https://github.com/your-org/project-llm-management.git
-cd project-llm-management
-```
-
-### 3. Configure GitHub Secrets
-Go to **Settings → Secrets and variables → Actions** and add:
-- `GEMINI_API_KEY` (for code review)
-- `GH_TOKEN` (GitHub token with repo access)
-
-### 4. Enable GitHub Projects v2
-- Navigate to your repository's **Projects** tab
-- Click **New project** and select **Table** or **Board**
-- Workflows will sync project updates automatically
-
-### 5. Create your first issue
-- Use one of the provided templates (Feature, Bug, Task)
-- Add the `auto-branch` label
-- A branch will be created automatically!
-
-## 📚 Documentation Structure
-
-- **[Getting Started](./getting-started/installation.md)**: Setup and first steps
-- **[QCM Specification](./QCM-Specification.md)**: Generate specification questionnaires with Gemini
-- **[Architecture](./architecture/overview.md)**: System design and components
-- **[Guides](./guides/setup-github-projects.md)**: How to use each feature
-
-## 🤖 How It Works
-
-```mermaid
-graph TD
-    A["Create Issue<br/>+ auto-branch label"] -->|GitHub Actions| B["Branch Creator<br/>Creates feat/123-title"]
-    B --> C["Develop Locally"]
-    C --> D["Push & Create PR"]
-    D -->|GitHub Actions| E["Code Reviewer<br/>Gemini analyzes code"]
-    D -->|GitHub Actions| F["CI Tests<br/>Run tests & lint"]
-    E --> G["Post Comments"]
-    F --> H["Report Results"]
-    G --> I["Developer Reviews<br/>& Fixes"]
-    H --> I
-    I -->|Ready| J["Merge to develop"]
-    J -->|GitHub Actions| K["Project Board<br/>Status → Done"]
-    K --> L["Deployed to preprod"]
-```
-
-## 📊 Project Tracking
-
-All work is tracked in **GitHub Projects v2** with three main views:
-
-### Backlog
-All future issues, sortable by priority and effort
-
-### Priority Board
-Current work in Kanban format:
-- **Backlog**: Not started
-- **In Progress**: Being worked on
-- **In QA**: Testing/Review
-- **Done**: Completed
-
-### Team Items
-Filter by assignee and sprint for personal tracking
-
-## 🔐 Security
-
-### Permissions Model
-- **Branch Creator**: Write access (create branches)
-- **Code Reviewer**: Read access (no modifications)
-- **Test Feedback**: Read access (comment only)
-- **Human maintainers**: Full permissions
-
-### API Keys
-All sensitive credentials stored in GitHub Secrets (never in git):
-```
-GH_TOKEN, GEMINI_API_KEY
-```
-
-## 🎓 Use Cases
-
-### ✅ Perfect For
-- Distributed teams with async workflows
-- Projects with many contributors
-- Continuous learning environments
-- DevOps-focused teams
-- Open-source projects
-
-### ⚠️ Consider Alternatives For
-- Real-time synchronous work
-- Projects requiring manual QA
-- Systems without GitHub
-
-## 🤝 Contributing
-
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on how to contribute to this template.
-
-## 📞 Support
-
-- 📖 **Documentation**: See [Getting Started](./getting-started/installation.md)
-- 💬 **Discussions**: GitHub Discussions tab
-- 🐛 **Issues**: Use the provided issue templates
-- 📧 **Email**: your-email@example.com
-
-## 📄 License
-
-MIT License - See [LICENSE](../LICENSE) file for details.
-
+---
+hide:
+  - navigation
+  - toc
 ---
 
-**Ready to get started?** → [Installation Guide](./getting-started/installation.md)
+<style>
+.md-typeset h1 {
+  font-size: 2.5em;
+  font-weight: 700;
+  margin-bottom: 0;
+}
+.hero-subtitle {
+  font-size: 1.3em;
+  color: var(--md-default-fg-color--light);
+  margin-top: 0.5em;
+  margin-bottom: 1.5em;
+}
+.stats-row {
+  display: flex;
+  justify-content: center;
+  gap: 3em;
+  margin: 2em 0;
+  flex-wrap: wrap;
+}
+.stat-item {
+  text-align: center;
+}
+.stat-number {
+  font-size: 2.2em;
+  font-weight: 700;
+  color: var(--md-primary-fg-color);
+  display: block;
+  line-height: 1.2;
+}
+.stat-label {
+  font-size: 0.85em;
+  color: var(--md-default-fg-color--light);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.cta-row {
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  margin: 2em 0;
+  flex-wrap: wrap;
+}
+.install-box {
+  background: var(--md-code-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 1.5em 2em;
+  max-width: 700px;
+  margin: 2em auto;
+  text-align: center;
+}
+.install-box code {
+  font-size: 0.95em;
+}
+.section-divider {
+  border: none;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  margin: 3em 0;
+}
+</style>
 
-**Want to learn more?** → [Architecture Overview](./architecture/overview.md)
+# Automated GitHub Project Management
 
-**Have questions?** → [FAQ](./faq.md)
+<p class="hero-subtitle">
+You vibe your code with AI? This template organizes everything else.<br>
+Issues, Kanban board, code reviews, branches — all automated. Zero config.
+</p>
+
+<div class="stats-row">
+  <div class="stat-item">
+    <span class="stat-number">8</span>
+    <span class="stat-label">Automated Workflows</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">1</span>
+    <span class="stat-label">Install Command</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">70%</span>
+    <span class="stat-label">Tasks Automated</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">0</span>
+    <span class="stat-label">Config Required</span>
+  </div>
+</div>
+
+<div class="cta-row">
+  <a href="Getting-Started/" class="md-button md-button--primary">Get Started</a>
+  <a href="https://github.com/dyvan/github-project-llm-management" class="md-button">View on GitHub</a>
+</div>
+
+<hr class="section-divider">
+
+## Install in one command
+
+<div class="install-box">
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dyvan/github-project-llm-management/main/install.sh | bash
+```
+
+</div>
+
+The setup wizard asks for your **GitHub token** and optional **Gemini API key**. Labels, project board, and workflows are configured automatically.
+
+<hr class="section-divider">
+
+## What you get
+
+<div class="grid cards" markdown>
+
+-   :material-view-dashboard:{ .lg .middle } **Auto Project Board**
+
+    ---
+
+    Issues and PRs are automatically added to your Kanban board. Status flows from Backlog to Done without manual updates.
+
+-   :material-source-branch:{ .lg .middle } **Automatic Branches**
+
+    ---
+
+    Add the `auto-branch` label to any issue. A branch `feat/123-title` is created and linked in seconds.
+
+-   :material-file-document-edit:{ .lg .middle } **Specification Questionnaire**
+
+    ---
+
+    Gemini generates a tailored questionnaire to clarify requirements before implementation starts.
+
+-   :material-robot:{ .lg .middle } **AI Code Review**
+
+    ---
+
+    Every PR is analyzed by Gemini AI with improvement suggestions, bug detection, and security checks.
+
+-   :material-test-tube:{ .lg .middle } **Automated Testing**
+
+    ---
+
+    Lint, tests, and build run on every PR. Results are posted as comments. No CI setup needed.
+
+-   :material-check-all:{ .lg .middle } **Auto-close Features**
+
+    ---
+
+    Parent issues close automatically when all sub-issues are done. No manual tracking required.
+
+</div>
+
+<hr class="section-divider">
+
+## Manual work vs. this template
+
+| Task | Without template | With template |
+|---|---|---|
+| Create a branch | Manual `git checkout -b` | Add label `auto-branch` |
+| Track issue status | Drag cards on the board | Automatic: Backlog → In Review → Done |
+| Code review | Wait for humans | Gemini reviews in seconds + human review |
+| Clarify requirements | Meetings, back-and-forth | Gemini generates a spec questionnaire |
+| Close parent issues | Remember to check manually | Auto-closes when sub-issues are done |
+| CI/CD setup | Write workflow YAML | Pre-configured, works out of the box |
+
+<hr class="section-divider">
+
+## How it works
+
+```mermaid
+graph LR
+    A["Create Issue"] --> B["Add label"]
+    B --> C["Branch created"]
+    C --> D["Develop & Push"]
+    D --> E["Open PR"]
+    E --> F["AI Review + CI"]
+    F --> G["Merge"]
+    G --> H["Done"]
+    style A fill:#4051b5,color:#fff
+    style H fill:#43a047,color:#fff
+```
+
+**You handle steps 1 through 5.** Everything after that is automated.
+
+<hr class="section-divider">
+
+## Get started in 3 steps
+
+### 1. Install the template
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dyvan/github-project-llm-management/main/install.sh | bash
+```
+
+### 2. Create your first issue
+
+```bash
+gh issue create --title "Add user authentication" --label "type:feature"
+gh issue edit 1 --add-label "auto-branch"
+```
+
+A branch is created automatically. Check it out and start coding.
+
+### 3. Open a PR and let automation take over
+
+```bash
+gh pr create --title "feat: Add user auth (#1)" --body "Closes #1"
+```
+
+Gemini reviews your code. CI runs tests. Merge it — the issue closes and the board updates.
+
+<hr class="section-divider">
+
+## Built for AI-assisted development
+
+Works with **Claude Code**, **Cursor**, **GitHub Copilot**, **Windsurf**, or plain `vim`. This template handles project management so you focus on shipping code.
+
+<div class="stats-row">
+  <div class="stat-item">
+    <span class="stat-number">:material-language-python:</span>
+    <span class="stat-label">Python 3.11+</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">:octicons-mark-github-16:</span>
+    <span class="stat-label">GitHub Actions</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">:material-robot:</span>
+    <span class="stat-label">Google Gemini</span>
+  </div>
+  <div class="stat-item">
+    <span class="stat-number">:material-book-open-variant:</span>
+    <span class="stat-label">MkDocs Material</span>
+  </div>
+</div>
+
+<hr class="section-divider">
+
+## FAQ
+
+??? question "Do I need a Gemini API key?"
+    It's optional. Without it, you still get automatic branches, project board sync, CI tests, and auto-close. The Gemini key enables AI code review and specification questionnaires.
+
+??? question "Can I use this with an existing repo?"
+    Yes. The install script clones the template into a new project, but you can also copy the workflows and scripts into an existing repo manually.
+
+??? question "Is this only for Python projects?"
+    No. The template works with any language. The Python scripts are for the automation layer (project sync, QCM generation). Your project code can be anything.
+
+??? question "What GitHub token scopes do I need?"
+    The token needs `repo`, `project`, and `workflow` scopes. The setup wizard will tell you exactly what to configure.
+
+<hr class="section-divider">
+
+<div style="text-align: center; margin: 2em 0;">
+  <a href="Getting-Started/" class="md-button md-button--primary" style="margin: 0.5em;">Get Started</a>
+  <a href="https://github.com/dyvan/github-project-llm-management" class="md-button" style="margin: 0.5em;">Star on GitHub</a>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,33 +1,36 @@
-site_name: Project LLM Management
-site_description: GitHub-based project management with LLM agents
-site_author: Your Team
-repo_url: https://github.com/your-org/project-llm-management
-repo_name: project-llm-management
+site_name: GitHub Project LLM Management
+site_description: Turnkey template for automated GitHub project management with AI
+site_author: dyvan
+site_url: https://dyvan.github.io/github-project-llm-management/
+repo_url: https://github.com/dyvan/github-project-llm-management
+repo_name: dyvan/github-project-llm-management
 
 theme:
   name: material
   icon:
     repo: fontawesome/brands/github
+    logo: material/robot-outline
   features:
     - content.code.copy
     - content.code.select
     - navigation.instant
     - navigation.tracking
     - navigation.top
+    - navigation.sections
     - toc.follow
     - search.suggest
     - search.highlight
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: blue
+      primary: indigo
       accent: amber
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: blue
+      primary: indigo
       accent: amber
       toggle:
         icon: material/brightness-4
@@ -50,26 +53,31 @@ markdown_extensions:
       use_pygments: true
   - pymdownx.arithmatex:
       generic: true
+  - attr_list
+  - md_in_html
   - toc:
       permalink: true
 
 nav:
   - Home: index.md
   - Getting Started:
+      - Overview: Getting-Started.md
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
       - First Issue: getting-started/first-issue.md
+  - User Guide:
+      - Using the Template: Using-The-Template.md
+      - Configuration: Configuration.md
+      - QCM Specification: QCM-Specification.md
+      - Scripts Reference: Scripts-Reference.md
   - Architecture:
       - Overview: architecture/overview.md
       - GitHub Projects v2: architecture/github-projects.md
       - Workflows: architecture/workflows.md
-      - Agents: architecture/agents.md
-  - Guides:
-      - GitHub Projects Setup: guides/setup-github-projects.md
-      - Using Agents: guides/using-agents.md
-      - Contributing: guides/contributing.md
-      - Troubleshooting: guides/troubleshooting.md
-  - API Reference:
-      - GitHub Actions: api/github-actions.md
-      - LLM Integration: api/llm-integration.md
-  - FAQ: faq.md
+      - Understanding Workflows: Understanding-Workflows.md
+  - Reference:
+      - Advanced Customization: Advanced-Customization.md
+      - Template Validation: Template-Validation.md
+      - Troubleshooting: Troubleshooting.md
+      - FAQ: faq.md
+  - Contributing: Contributing.md


### PR DESCRIPTION
## Summary
- New landing page for GitHub Pages (`docs/index.md`) inspired by nanoclaw.net's minimalist style
- Fixed mkdocs.yml navigation to only reference existing files
- Fixed broken links to deleted `guides/` directory

## Landing Page Features
- Hero section with tagline and stats row (8 workflows, 1 command, 70% automated, 0 config)
- Feature cards grid with Material Design icons
- "Manual vs. Template" comparison table
- Mermaid workflow diagram
- 3-step getting started guide with code blocks
- FAQ accordion (collapsible)
- Dual CTA buttons (Get Started + GitHub)
- Dark mode compatible via CSS variables
- Mobile responsive

## Other Changes
- `mkdocs.yml`: Updated repo URL, reorganized nav into 5 sections matching existing files
- Fixed 5 broken links in `getting-started/` docs pointing to deleted `guides/` pages
- Added `site/` to `.gitignore`

## Test plan
- [x] `mkdocs build` succeeds with no errors
- [x] 32 unit tests pass
- [x] No broken nav links to missing files

## Next step after merge
Enable GitHub Pages: Settings > Pages > Source: Deploy from branch `gh-pages`

Closes #88