### PR TITLE
feat: Add /next-task command to auto-pick work from board (#112)

### DIFF
--- a/.claude/commands/next-task.md
+++ b/.claude/commands/next-task.md
@@ -1,0 +1,114 @@
+---
+description: Auto-pick the next task from the project board (Ready, sorted by Priority > Milestone > Effort)
+allowed-tools: Bash(gh:*), Bash(GITHUB_TOKEN=:*), Read
+---
+
+# Next Task
+
+Query the GitHub Project board and recommend the next task to work on.
+
+## Steps
+
+1. **Query the project board for Ready items**:
+   Run a GraphQL query to fetch all items with Status = "Ready" from the project board:
+   ```
+   GITHUB_TOKEN= gh api graphql -f query='
+   {
+     node(id: "PVT_kwHOAX_dWc4BGnys") {
+       ... on ProjectV2 {
+         items(first: 100) {
+           nodes {
+             id
+             fieldValues(first: 20) {
+               nodes {
+                 ... on ProjectV2ItemFieldSingleSelectValue {
+                   field { ... on ProjectV2SingleSelectField { name } }
+                   optionId
+                   name
+                 }
+                 ... on ProjectV2ItemFieldMilestoneValue {
+                   field { ... on ProjectV2Field { name } }
+                   milestone {
+                     title
+                     dueOn
+                   }
+                 }
+               }
+             }
+             content {
+               ... on Issue {
+                 number
+                 title
+                 url
+                 labels(first: 10) { nodes { name } }
+                 assignees(first: 5) { nodes { login } }
+                 milestone {
+                   title
+                   dueOn
+                 }
+               }
+             }
+           }
+         }
+       }
+     }
+   }'
+   ```
+
+2. **Filter for Ready items only**:
+   From the results, keep only items where the Status field optionId is `61e4505c` (Ready).
+
+3. **Sort candidates** using this priority order:
+   a. **Priority** (highest first):
+      - P0 (`79628723`) — most urgent
+      - P1 (`0a877460`)
+      - P2 (`da944a9c`)
+      - No priority — lowest
+   b. **Milestone due date** (earliest first):
+      - Items with a milestone due date sort before those without
+      - Earlier due dates sort first
+   c. **Effort** (smallest first, to favor quick wins at same priority):
+      - 1 (`08e40e54`)
+      - 2 (`8296128d`)
+      - 3 (`94ddd87f`)
+      - 5 (`61b3d099`)
+      - 8 (`02981c20`)
+      - No effort — sort last
+
+4. **Display top 3 candidates**:
+   Format the output as a ranked list:
+   ```
+   ## Next Task Candidates
+
+   ### #1 Pick
+   - Issue: #{number} - {title}
+   - Priority: {P0/P1/P2}
+   - Milestone: {milestone title} (due {date})
+   - Effort: {points} points
+   - Labels: {labels}
+   - URL: {url}
+
+   ### #2
+   ...
+
+   ### #3
+   ...
+   ```
+
+   If no Ready items are found, report:
+   ```
+   No tasks with Status = "Ready" found on the project board.
+   Consider moving items from Backlog to Ready, or run /sprint-report to review the board.
+   ```
+
+5. **Ask the user**:
+   After displaying the candidates, ask:
+   > "Would you like to start working on #{top-pick-number}? (I will run /start-task {number})"
+
+   Wait for confirmation before doing anything else.
+
+## Important
+- Use `GITHUB_TOKEN= gh ...` for all gh commands (uses dyvan account)
+- The project board ID is `PVT_kwHOAX_dWc4BGnys`
+- This is a read-only command — do not modify anything
+- Do NOT automatically start a task; always ask for confirmation first

--- a/tests/test_next_task_command.py
+++ b/tests/test_next_task_command.py
@@ -1,0 +1,167 @@
+"""
+Tests for the /next-task Claude Code slash command.
+Validates structure, frontmatter, content, and conventions.
+"""
+
+import re
+import pytest
+from pathlib import Path
+
+
+COMMANDS_DIR = Path(__file__).parent.parent / ".claude" / "commands"
+COMMAND_FILE = COMMANDS_DIR / "next-task.md"
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+FIELD_RE = re.compile(r"^(\w[\w-]*):\s*(.+)$", re.MULTILINE)
+
+
+def parse_frontmatter(content: str) -> dict:
+    """Parse YAML-like frontmatter from a command file."""
+    match = FRONTMATTER_RE.match(content)
+    if not match:
+        return {}
+    return dict(FIELD_RE.findall(match.group(1)))
+
+
+@pytest.fixture
+def command_content():
+    """Read the next-task command file."""
+    assert COMMAND_FILE.exists(), "next-task.md does not exist"
+    return COMMAND_FILE.read_text()
+
+
+@pytest.fixture
+def command_meta(command_content):
+    """Parse frontmatter from the command."""
+    return parse_frontmatter(command_content)
+
+
+class TestNextTaskFileExists:
+    """Test that the next-task command file exists."""
+
+    def test_file_exists(self):
+        assert COMMAND_FILE.exists(), (
+            ".claude/commands/next-task.md does not exist"
+        )
+
+    def test_file_is_not_empty(self):
+        assert COMMAND_FILE.stat().st_size > 0, (
+            "next-task.md is empty"
+        )
+
+
+class TestNextTaskFrontmatter:
+    """Test that next-task.md has valid frontmatter."""
+
+    def test_has_frontmatter(self, command_content):
+        assert FRONTMATTER_RE.match(command_content), (
+            "next-task.md is missing YAML frontmatter (--- delimiters)"
+        )
+
+    def test_has_description(self, command_meta):
+        assert "description" in command_meta, (
+            "next-task.md missing 'description' in frontmatter"
+        )
+
+    def test_description_is_meaningful(self, command_meta):
+        desc = command_meta.get("description", "").lower()
+        assert "next" in desc or "pick" in desc or "task" in desc, (
+            f"next-task.md description should mention next/pick/task, got: {desc}"
+        )
+
+    def test_has_allowed_tools(self, command_meta):
+        assert "allowed-tools" in command_meta, (
+            "next-task.md missing 'allowed-tools' in frontmatter"
+        )
+
+    def test_allowed_tools_include_gh(self, command_meta):
+        tools = command_meta.get("allowed-tools", "")
+        assert "Bash(gh:*)" in tools or "Bash(GITHUB_TOKEN=:*)" in tools, (
+            "next-task.md should allow gh commands"
+        )
+
+    def test_no_argument_hint(self, command_meta):
+        """next-task takes no arguments."""
+        assert "argument-hint" not in command_meta, (
+            "next-task.md should NOT have 'argument-hint' (takes no arguments)"
+        )
+
+
+class TestNextTaskContent:
+    """Test the body content of next-task.md."""
+
+    def test_has_steps_section(self, command_content):
+        assert "## Steps" in command_content, (
+            "next-task.md should have a '## Steps' section"
+        )
+
+    def test_references_project_id(self, command_content):
+        assert "PVT_kwHOAX_dWc4BGnys" in command_content, (
+            "next-task.md should reference the project board ID"
+        )
+
+    def test_references_github_token_prefix(self, command_content):
+        assert "GITHUB_TOKEN=" in command_content, (
+            "next-task.md should use 'GITHUB_TOKEN= gh' for dyvan account"
+        )
+
+    def test_references_ready_status(self, command_content):
+        """Should filter for Ready items."""
+        assert "61e4505c" in command_content or "Ready" in command_content, (
+            "next-task.md should reference Ready status"
+        )
+
+    def test_references_priority_field_ids(self, command_content):
+        """Should reference priority option IDs for sorting."""
+        assert "79628723" in command_content, (
+            "next-task.md should reference P0 priority option ID"
+        )
+        assert "0a877460" in command_content, (
+            "next-task.md should reference P1 priority option ID"
+        )
+        assert "da944a9c" in command_content, (
+            "next-task.md should reference P2 priority option ID"
+        )
+
+    def test_references_effort_field_ids(self, command_content):
+        """Should reference effort option IDs for sorting."""
+        assert "08e40e54" in command_content, (
+            "next-task.md should reference effort 1 option ID"
+        )
+
+    def test_mentions_milestone_sorting(self, command_content):
+        content_lower = command_content.lower()
+        assert "milestone" in content_lower, (
+            "next-task.md should mention milestone for sorting"
+        )
+
+    def test_no_hardcoded_secrets(self, command_content):
+        assert "ghp_" not in command_content, (
+            "next-task.md contains hardcoded GitHub token"
+        )
+        assert "sk-" not in command_content, (
+            "next-task.md contains hardcoded API key"
+        )
+        assert "AIza" not in command_content, (
+            "next-task.md contains hardcoded Gemini API key"
+        )
+
+    def test_is_read_only(self, command_content):
+        """Command should be read-only and not modify anything."""
+        content_lower = command_content.lower()
+        assert "read-only" in content_lower or "do not modify" in content_lower, (
+            "next-task.md should state it is read-only"
+        )
+
+    def test_asks_user_before_starting(self, command_content):
+        """Should ask confirmation before invoking start-task."""
+        content_lower = command_content.lower()
+        assert "ask" in content_lower or "confirm" in content_lower, (
+            "next-task.md should ask user for confirmation before starting a task"
+        )
+
+    def test_displays_candidates(self, command_content):
+        """Should display top candidates."""
+        assert "top" in command_content.lower() or "#1" in command_content or "candidates" in command_content.lower(), (
+            "next-task.md should display top candidates"
+        )


### PR DESCRIPTION
## Summary
- Add `/next-task` slash command that queries the GitHub Project board for items with Status = "Ready"
- Sorts candidates by Priority (P0 > P1 > P2), then Milestone due date (earliest first), then Effort (smallest first)
- Displays top 3 candidates and asks for confirmation before starting work
- Add 19 tests in `tests/test_next_task_command.py` covering file existence, frontmatter validation, content conventions, and safety checks

Closes #112

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

## Changes Made
- `.claude/commands/next-task.md` — new slash command with GraphQL query, sorting logic, and formatted output
- `tests/test_next_task_command.py` — 19 tests validating structure, frontmatter (description, allowed-tools, no argument-hint), project ID references, GITHUB_TOKEN= pattern, read-only behavior, and no hardcoded secrets

## Test plan
- [x] `python3 -m pytest tests/test_next_task_command.py -v` — 19/19 passed