### PR TITLE
fix: Stop generate-specification from committing files to repo (#104)

### DIFF
--- a/.github/workflows/generate-specification.yml
+++ b/.github/workflows/generate-specification.yml
@@ -11,7 +11,7 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 jobs:
@@ -73,14 +73,6 @@ jobs:
             --save-files \
             --create-sub-issue
 
-      - name: Commit specification files
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add specifications/
-          git commit -m "docs: Add specification for issue #${{ steps.issue.outputs.number }}" || echo "No changes to commit"
-          git push
-
       - name: Add ready labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +91,6 @@ jobs:
           echo "   Status: ✅ Completed"
           echo ""
           echo "Generated:"
-          echo "   ✅ Specification files saved to specifications/issue-${{ steps.issue.outputs.number }}/"
           echo "   ✅ Sub-issue created with detailed specification"
           echo "   ✅ Labels added: auto-branch, specifications-ready"
           echo ""

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -111,7 +111,6 @@ gh pr merge 45
 **What happens**:
 - Reads QCM responses from issue comments
 - Gemini AI generates a detailed specification document
-- Specification saved to `specifications/issue-{number}/`
 - Sub-issue created with the specification
 - Labels `auto-branch` and `specifications-ready` added
 


### PR DESCRIPTION
## Summary

- Removed the `Commit specification files` step from `generate-specification.yml` that was committing spec files to `specifications/` in the repo
- Downgraded `contents` permission from `write` to `read` (no longer needed)
- Updated `AUTOMATION.md` to remove reference to spec files being saved to disk
- The spec content is already posted as a sub-issue comment, making the file commit redundant

Closes #104

## Test plan

- [x] All 135 existing tests pass (`python3 -m pytest tests/ -v`)
- [x] Workflow YAML validates successfully
- [x] No other files reference the removed commit step