### PR TITLE
chore: Isolate E2E workflows from template distribution (#95)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,37 @@ project-name/
 
 ---
 
-## 💻 Tech Stack
+## Workflows: Template vs Internal
+
+Not all workflow files in `.github/workflows/` are distributed to template users. The setup step `5-copy-files.sh` uses an explicit whitelist.
+
+**Template workflows** (distributed to users):
+
+| Workflow | Purpose |
+|---|---|
+| `create-branch.yml` | Auto-create branch from issue |
+| `code-review-agent.yml` | Gemini AI code review |
+| `auto-close-feature.yml` | Auto-close parent when subs done |
+| `generate-specification.yml` | Gemini generates detailed spec |
+| `plan-with-gemini.yml` | Gemini generates spec questionnaire |
+| `update-project.yml` | Sync project board |
+| `ci-tests.yml` | Lint, tests, build |
+| `deploy-docs.yml` | Deploy MkDocs to GitHub Pages |
+
+**Internal workflows** (NOT distributed, development-only):
+
+| Workflow | Purpose |
+|---|---|
+| `e2e-test-template.yml` | End-to-end template validation |
+| `e2e-test-install.yml` | End-to-end install flow test |
+| `template-validation.yml` | Template structure validation |
+| `auto-add-to-project.yml` | Auto-add items to project board (repo-specific) |
+
+A CI test (`tests/test_template_distribution.py`) enforces that internal workflows never appear in the whitelist.
+
+---
+
+## Tech Stack
 
 ### Languages
 - **Python 3.11+** (primary language)

--- a/template/.setup/steps/5-copy-files.sh
+++ b/template/.setup/steps/5-copy-files.sh
@@ -21,7 +21,10 @@ copy_workflows() {
 
     mkdir -p "$dest"
 
-    # Workflows to copy (user-relevant only)
+    # WHITELIST: Only these workflows are distributed to template users.
+    # Internal/E2E workflows (e2e-test-template.yml, e2e-test-install.yml,
+    # template-validation.yml, auto-add-to-project.yml) are intentionally
+    # excluded -- they are development-only and must never be shipped.
     local workflows=(
         "create-branch.yml"
         "code-review-agent.yml"
@@ -29,6 +32,8 @@ copy_workflows() {
         "generate-specification.yml"
         "plan-with-gemini.yml"
         "update-project.yml"
+        "ci-tests.yml"
+        "deploy-docs.yml"
     )
 
     local count=0

--- a/tests/test_template_distribution.py
+++ b/tests/test_template_distribution.py
@@ -1,0 +1,87 @@
+"""
+Tests to ensure internal/E2E workflows are never distributed to template users.
+
+The whitelist in template/.setup/steps/5-copy-files.sh controls which
+workflows are copied during setup. This test reads that whitelist and
+verifies correctness.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+COPY_STEP = REPO_ROOT / "template" / ".setup" / "steps" / "5-copy-files.sh"
+
+# Internal workflows that must NEVER be distributed
+INTERNAL_WORKFLOWS = [
+    "e2e-test-template.yml",
+    "e2e-test-install.yml",
+    "template-validation.yml",
+    "auto-add-to-project.yml",
+]
+
+# Template workflows that SHOULD be distributed
+EXPECTED_TEMPLATE_WORKFLOWS = [
+    "create-branch.yml",
+    "code-review-agent.yml",
+    "auto-close-feature.yml",
+    "generate-specification.yml",
+    "plan-with-gemini.yml",
+    "update-project.yml",
+    "ci-tests.yml",
+    "deploy-docs.yml",
+]
+
+
+def _parse_whitelist() -> list[str]:
+    """Extract the workflows array from 5-copy-files.sh."""
+    content = COPY_STEP.read_text()
+    # Match the bash array block: local workflows=( ... )
+    match = re.search(
+        r'local workflows=\(\s*(.*?)\)', content, re.DOTALL
+    )
+    assert match, "Could not find 'local workflows=(...)' in 5-copy-files.sh"
+    block = match.group(1)
+    # Extract quoted strings
+    return re.findall(r'"([^"]+)"', block)
+
+
+class TestTemplateDistribution:
+    """Verify the workflow distribution whitelist is correct."""
+
+    @pytest.fixture(autouse=True)
+    def whitelist(self):
+        self._whitelist = _parse_whitelist()
+
+    def test_copy_step_exists(self):
+        assert COPY_STEP.exists(), f"{COPY_STEP} not found"
+
+    def test_internal_workflows_excluded(self):
+        """Internal/E2E workflows must NOT appear in the whitelist."""
+        for wf in INTERNAL_WORKFLOWS:
+            assert wf not in self._whitelist, (
+                f"Internal workflow '{wf}' must not be in the distribution whitelist"
+            )
+
+    def test_expected_template_workflows_included(self):
+        """All expected template workflows must appear in the whitelist."""
+        for wf in EXPECTED_TEMPLATE_WORKFLOWS:
+            assert wf in self._whitelist, (
+                f"Template workflow '{wf}' is missing from the distribution whitelist"
+            )
+
+    def test_no_e2e_prefix_in_whitelist(self):
+        """No workflow starting with 'e2e-' should be distributed."""
+        for wf in self._whitelist:
+            assert not wf.startswith("e2e-"), (
+                f"Workflow '{wf}' starts with 'e2e-' and should not be distributed"
+            )
+
+    def test_no_template_prefix_in_whitelist(self):
+        """No workflow starting with 'template-' should be distributed."""
+        for wf in self._whitelist:
+            assert not wf.startswith("template-"), (
+                f"Workflow '{wf}' starts with 'template-' and should not be distributed"
+            )


### PR DESCRIPTION
## Summary

- Added explicit whitelist comment in `template/.setup/steps/5-copy-files.sh` explaining which workflows are distributed to template users and why internal ones are excluded
- Added `ci-tests.yml` and `deploy-docs.yml` to the distribution whitelist (useful for template users)
- Documented template vs internal workflows in `CONTRIBUTING.md` with a clear table
- Added CI test (`tests/test_template_distribution.py`) that parses the whitelist from `5-copy-files.sh` and verifies internal workflows (e2e-*, template-*, auto-add-to-project) are never distributed

Closes #95

## Test plan

- [x] `python3 -m pytest tests/ -v` -- all 140 tests pass (5 new)
- [x] New test correctly parses the bash array and validates both inclusion and exclusion lists
- [x] New test catches any `e2e-` or `template-` prefixed workflow sneaking into the whitelist