### PR TITLE
feat: Add pre-configured Claude Code hooks (#100)

### DIFF
--- a/.claude/hooks/post-commit-update.sh
+++ b/.claude/hooks/post-commit-update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Post-commit hook: extracts issue number from the last commit and logs it.
+# In the future, this could update the project board automatically.
+# Uses GITHUB_TOKEN= gh to target the dyvan account.
+
+set -euo pipefail
+
+# Get the last commit message
+COMMIT_MSG=$(git log -1 --pretty=%B 2>/dev/null || true)
+
+if [ -z "$COMMIT_MSG" ]; then
+  exit 0
+fi
+
+# Extract issue number(s) from the commit message
+ISSUES=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | sort -u || true)
+
+if [ -z "$ISSUES" ]; then
+  echo "No issue reference found in commit message."
+  exit 0
+fi
+
+for ISSUE in $ISSUES; do
+  NUM=$(echo "$ISSUE" | tr -d '#')
+  echo "Issue #${NUM} referenced in commit."
+done

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Pre-commit hook: validates that the commit message references an issue (#NNN).
+# Receives JSON on stdin from Claude Code with tool input containing the commit message.
+# Exits non-zero if no issue reference is found.
+
+set -euo pipefail
+
+# Read stdin (Claude Code passes JSON with tool name and input)
+INPUT=$(cat)
+
+# Extract the commit message from the input
+# The input JSON contains the bash command; we look for the commit message pattern
+COMMIT_MSG=$(echo "$INPUT" | grep -oE '"command"\s*:\s*"[^"]*"' | head -1 | sed 's/"command"\s*:\s*"//;s/"$//' || true)
+
+# If we couldn't extract from JSON, use the raw input
+if [ -z "$COMMIT_MSG" ]; then
+  COMMIT_MSG="$INPUT"
+fi
+
+# Check for issue reference pattern (#NNN)
+if echo "$COMMIT_MSG" | grep -qE '#[0-9]+'; then
+  exit 0
+fi
+
+echo "ERROR: Commit message must reference an issue (#NNN)."
+echo "Example: git commit -m \"feat: add feature X (#123)\""
+exit 1

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Session end hook: saves current state to .ai/session-state.md.
+# Captures branch, last commit, and timestamp.
+
+set -euo pipefail
+
+mkdir -p .ai
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+LAST_COMMIT=$(git log -1 --oneline 2>/dev/null || echo "no commits")
+DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+cat > .ai/session-state.md <<EOF
+# Session State
+
+- **Date**: ${DATE}
+- **Branch**: ${BRANCH}
+- **Last commit**: ${LAST_COMMIT}
+EOF
+
+echo "Session state saved to .ai/session-state.md"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Session start hook: outputs saved session state and current git context.
+# Checks for .ai/session-state.md and outputs its content if present.
+
+set -euo pipefail
+
+# Output saved session state if it exists
+if [ -f ".ai/session-state.md" ]; then
+  echo "=== Previous Session State ==="
+  cat .ai/session-state.md
+  echo ""
+fi
+
+# Output current git context
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+LAST_COMMIT=$(git log -1 --oneline 2>/dev/null || echo "no commits")
+
+echo "=== Current Context ==="
+echo "Branch: ${BRANCH}"
+echo "Last commit: ${LAST_COMMIT}"

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,46 @@
+# Claude Code Hooks
+
+Pre-configured hooks that automate context loading and project management updates.
+
+## Available Hooks
+
+| Hook | File | Trigger | Purpose |
+|------|------|---------|---------|
+| Pre-commit check | `pre-commit-check.sh` | Before `git commit` | Validates commit message references an issue (#NNN) |
+| Post-commit update | `post-commit-update.sh` | After `git commit` | Logs referenced issue numbers |
+| Session start | `session-start.sh` | Session notification | Loads saved state from `.ai/session-state.md` |
+| Session end | `session-end.sh` | Session stop | Saves branch, commit, and timestamp to `.ai/session-state.md` |
+
+## How to Enable
+
+1. Copy the template settings file to your project:
+   ```bash
+   cp template/config/claude-settings.json .claude/settings.json
+   ```
+
+2. Make hook scripts executable:
+   ```bash
+   chmod +x .claude/hooks/*.sh
+   ```
+
+3. Restart Claude Code to pick up the new settings.
+
+## How to Customize
+
+- Edit `.claude/settings.json` to add, remove, or change hook bindings.
+- Edit scripts in `.claude/hooks/` to modify behavior.
+- The `matcher` field in settings controls which tool invocations trigger the hook.
+  Use `""` to match all invocations, or a pattern like `Bash(git commit:*)` for specific ones.
+
+## Hook Types
+
+- **PreToolUse**: Runs before a tool call. Exit non-zero to block the call.
+- **PostToolUse**: Runs after a tool call completes.
+- **Notification**: Runs on session notifications.
+- **Stop**: Runs when the session ends.
+
+## Notes
+
+- Hooks receive JSON on stdin with tool name, input, and output.
+- Keep hooks fast (under 1 second) to avoid slowing down the workflow.
+- The `.ai/` directory is used for session state and should be added to `.gitignore`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,4 +83,5 @@ nav:
       - Template Validation: Template-Validation.md
       - Troubleshooting: Troubleshooting.md
       - FAQ: faq.md
+      - Hooks: hooks.md
   - Contributing: Contributing.md

--- a/template/config/claude-settings.json
+++ b/template/config/claude-settings.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-check.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash(git commit:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-commit-update.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,90 @@
+"""
+Tests for Claude Code hook scripts and configuration.
+"""
+
+import json
+import os
+import stat
+import subprocess
+
+import pytest
+
+# Root of the repository
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HOOKS_DIR = os.path.join(ROOT_DIR, ".claude", "hooks")
+TEMPLATE_SETTINGS = os.path.join(ROOT_DIR, "template", "config", "claude-settings.json")
+DOCS_HOOKS = os.path.join(ROOT_DIR, "docs", "hooks.md")
+
+HOOK_SCRIPTS = [
+    "pre-commit-check.sh",
+    "post-commit-update.sh",
+    "session-start.sh",
+    "session-end.sh",
+]
+
+
+class TestHookScriptsExist:
+    """All hook scripts must exist."""
+
+    @pytest.mark.parametrize("script", HOOK_SCRIPTS)
+    def test_hook_script_exists(self, script):
+        path = os.path.join(HOOKS_DIR, script)
+        assert os.path.isfile(path), f"Hook script missing: {path}"
+
+
+class TestHookScriptsSyntax:
+    """All hook scripts must have valid bash syntax."""
+
+    @pytest.mark.parametrize("script", HOOK_SCRIPTS)
+    def test_hook_script_valid_bash(self, script):
+        path = os.path.join(HOOKS_DIR, script)
+        result = subprocess.run(
+            ["bash", "-n", path],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Bash syntax error in {script}: {result.stderr}"
+        )
+
+
+class TestHookScriptsExecutable:
+    """All hook scripts should be executable or can be made executable."""
+
+    @pytest.mark.parametrize("script", HOOK_SCRIPTS)
+    def test_hook_script_executable(self, script):
+        path = os.path.join(HOOKS_DIR, script)
+        st = os.stat(path)
+        is_executable = bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+        assert is_executable, (
+            f"Hook script not executable: {script}. "
+            f"Run: chmod +x {path}"
+        )
+
+
+class TestTemplateSettings:
+    """Template settings file must exist and be valid JSON."""
+
+    def test_template_settings_exists(self):
+        assert os.path.isfile(TEMPLATE_SETTINGS), (
+            f"Template settings missing: {TEMPLATE_SETTINGS}"
+        )
+
+    def test_template_settings_valid_json(self):
+        with open(TEMPLATE_SETTINGS) as f:
+            data = json.load(f)
+        assert "hooks" in data, "Template settings must contain a 'hooks' key"
+
+    def test_template_settings_has_hook_types(self):
+        with open(TEMPLATE_SETTINGS) as f:
+            data = json.load(f)
+        hooks = data["hooks"]
+        assert "PreToolUse" in hooks, "Missing PreToolUse in template settings"
+        assert "PostToolUse" in hooks, "Missing PostToolUse in template settings"
+
+
+class TestDocumentation:
+    """Documentation file must exist."""
+
+    def test_docs_hooks_exists(self):
+        assert os.path.isfile(DOCS_HOOKS), f"Documentation missing: {DOCS_HOOKS}"


### PR DESCRIPTION
## Summary

- Add 4 hook scripts in `.claude/hooks/` for commit validation, issue tracking, and session state management
- Add `template/config/claude-settings.json` as an opt-in template for wiring hooks
- Add `docs/hooks.md` documentation and `tests/test_hooks.py` (16 tests, all passing)

Closes #100

## Changes

### Hook scripts (`.claude/hooks/`)
| Script | Purpose |
|--------|---------|
| `pre-commit-check.sh` | Validates commit messages contain an issue reference (#NNN) |
| `post-commit-update.sh` | Logs referenced issue numbers after a commit |
| `session-start.sh` | Outputs saved session state and current git context |
| `session-end.sh` | Saves branch, last commit, and timestamp to `.ai/session-state.md` |

### Template settings
- `template/config/claude-settings.json` wires all 4 hooks into Claude Code's hook system (PreToolUse, PostToolUse, Notification, Stop)
- Users opt-in by copying this file to `.claude/settings.json`

### Documentation and tests
- `docs/hooks.md`: explains available hooks, how to enable and customize them
- `tests/test_hooks.py`: 16 tests covering script existence, bash syntax validity, executable permissions, JSON validity, and documentation presence
- Added hooks.md to mkdocs nav

## Test plan

- [x] `python3 -m pytest tests/test_hooks.py -v` -- 16/16 passed
- [x] `bash -n` syntax check on all hook scripts
- [x] Template settings is valid JSON with correct structure