### PR TITLE
feat: Add project memory structure for persistent AI context (#98)

### DIFF
--- a/.ai/memory/architecture.md
+++ b/.ai/memory/architecture.md
@@ -1,0 +1,55 @@
+# Architecture
+
+> System design, components, and data flow for the project.
+> Update this file as the architecture evolves.
+
+## Overview
+
+Template for automated GitHub project management with AI (Gemini) integration.
+
+## Setup Flow
+
+```
+install.sh (curl) -> bootstrap.sh -> template-setup.sh -> template/.setup/setup.sh
+```
+
+Setup runs 6 idempotent steps tracked via `.setup-state.json`:
+1. Check state
+2. Check prerequisites (gh CLI, git, Python)
+3. Initialize labels
+4. Create project board
+5. Copy files (workflows, templates, scripts, commands)
+6. Finalize
+
+## Key Components
+
+### GitHub Actions Workflows (`.github/workflows/`)
+- `create-branch.yml` -- auto-create branch from issue (trigger: label `auto-branch`)
+- `code-review-agent.yml` -- Gemini AI code review on PRs
+- `ci-tests.yml` -- lint, tests, build on push/PR
+- `deploy-docs.yml` -- deploy MkDocs to GitHub Pages
+- `update-project.yml` -- sync project board on events
+- `plan-with-gemini.yml` -- Gemini generates spec questionnaire
+- `generate-specification.yml` -- Gemini generates detailed spec
+- `auto-close-feature.yml` -- auto-close parent when sub-issues done
+
+### Scripts (`scripts/`)
+- `project_sync.py` -- sync project board via GraphQL
+- `auto_close_parent_feature.py` -- check and close parent issues
+- `generate_specification.py` -- generate specs from questionnaire
+- `generate_qcm.py` -- generate planning questionnaire
+
+### Setup (`template/.setup/`)
+- `setup.sh` -- orchestrator for 6 setup steps
+- `steps/` -- individual step scripts (1 through 6)
+- `lib/` -- shared bash helpers (colors, state management)
+
+### Documentation (`docs/`)
+- MkDocs Material site deployed via GitHub Pages
+
+## Data Flow
+
+```
+Issue created -> auto-add to project board -> label triggers branch creation
+-> development -> PR -> Gemini review -> CI checks -> merge -> auto-close
+```

--- a/.ai/memory/conventions.md
+++ b/.ai/memory/conventions.md
@@ -1,0 +1,66 @@
+# Conventions
+
+> Code style, naming patterns, and workflow conventions.
+> Follow these consistently across the project.
+
+## Branch Naming
+
+| Type        | Pattern                                  | Example                          |
+|-------------|------------------------------------------|----------------------------------|
+| Feature     | `feat/{issue}-{short-description}`       | `feat/98-project-memory`         |
+| Bug fix     | `fix/{issue}-{short-description}`        | `fix/124-auth-bug`               |
+| Docs        | `docs/{issue}-{short-description}`       | `docs/125-api-docs`              |
+| Refactor    | `refactor/{issue}-{short-description}`   | `refactor/126-simplify-queries`  |
+
+## Commit Messages (Conventional Commits)
+
+Format: `type(scope): description (#issue-number)`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`
+
+Rules:
+- Always reference the issue: `(#123)`
+- Title under 72 characters
+- One commit = one logical change
+- No marketing-speak in messages
+
+## GitHub Accounts
+
+- **dyvan**: personal account (repo owner). Use `GITHUB_TOKEN= gh ...` to target.
+- **yvandtrusk**: pro account, active by default in gh CLI via GITHUB_TOKEN env var.
+
+## Labels
+
+Required on every issue:
+- **Type**: `type:feature`, `type:bug`, `type:task`, `type:docs`, `type:infrastructure`
+- **Priority**: `priority:high`, `priority:medium`, `priority:low`
+
+Automatic via workflows:
+- **Status**: `status:backlog`, `status:ready`, `status:in-progress`, `status:in-review`, `status:done`
+
+## Story Points Scale
+
+| Points | Meaning                    |
+|--------|----------------------------|
+| 1      | < 1 hour, trivial change   |
+| 2      | 2-4 hours, simple change   |
+| 3      | 1 day, medium change       |
+| 5      | 2-3 days, complex change   |
+| 8      | 1 week, very complex       |
+
+If > 8 points, break down into multiple issues.
+
+## Bash Scripting
+
+- Use `VAR=$((VAR+1))` not `((VAR++))` (fails under `set -e` when VAR=0)
+- Avoid `declare -A` (not portable to zsh)
+- Scripts must be executable (`chmod +x`)
+
+## File Organization
+
+- Workflows: `.github/workflows/`
+- Scripts: `scripts/`
+- Setup: `template/.setup/`
+- Docs: `docs/`
+- AI memory: `.ai/memory/`
+- Claude commands: `.claude/commands/`

--- a/.ai/memory/current-sprint.md
+++ b/.ai/memory/current-sprint.md
@@ -1,0 +1,39 @@
+# Current Sprint
+
+> Active work, priorities, and blockers.
+> Updated manually or via `scripts/update-memory.sh`.
+
+## Sprint Info
+
+- **Sprint**: (current)
+- **Last updated**: (auto-populated by update-memory.sh)
+
+## In Progress
+
+<!-- Items currently being worked on. Auto-populated by update-memory.sh -->
+
+_No items in progress._
+
+## Blockers
+
+<!-- Anything blocking progress -->
+
+_No blockers._
+
+## In Review
+
+<!-- PRs waiting for review -->
+
+_No items in review._
+
+## Next Up
+
+<!-- High-priority items from Ready queue -->
+
+_Run `scripts/update-memory.sh` to populate from GitHub._
+
+## Recently Completed
+
+<!-- Items closed this week -->
+
+_Run `scripts/update-memory.sh` to populate from GitHub._

--- a/.ai/memory/decisions.md
+++ b/.ai/memory/decisions.md
@@ -1,0 +1,42 @@
+# Decisions
+
+> Architecture Decision Records (ADRs) -- key choices and their rationale.
+> Add new decisions at the bottom with a date.
+
+## ADR-001: Gemini for all AI workflows (2025-11)
+
+**Decision**: Use Google Gemini for all AI-powered workflows (code review, planning, specification).
+
+**Rationale**: Free tier available, good quality output, single provider simplifies configuration.
+
+**Alternatives considered**: Claude API, OpenAI API -- higher cost, no significant quality advantage for these tasks.
+
+## ADR-002: Slash commands over CLAUDE.md tutorials (2026-02)
+
+**Decision**: Replace long CLAUDE.md workflow tutorials with slash commands in `.claude/commands/`.
+
+**Rationale**: Zero context cost -- commands load only when invoked. CLAUDE.md tutorials consumed tokens on every interaction.
+
+## ADR-003: Gemini features are opt-in (2026-03)
+
+**Decision**: Keep Gemini workflows but make them opt-in, not required for template users.
+
+**Rationale**: Template should work without any AI API keys. Users who want AI features can enable them.
+
+## ADR-004: Per-workflow API keys with fallback (2025-12)
+
+**Decision**: Support dedicated keys (GEMINI_PLAN_API_KEY, GEMINI_SPEC_API_KEY, GEMINI_REVIEW_API_KEY) with fallback to GEMINI_API_KEY.
+
+**Rationale**: Allows rate-limit isolation per workflow while keeping simple single-key setup as default.
+
+## ADR-005: Setup idempotency via state file (2025-11)
+
+**Decision**: Track setup progress in `.setup-state.json` so steps can be re-run safely.
+
+**Rationale**: Users may interrupt setup or need to re-run after fixing an issue. Idempotent steps prevent duplication.
+
+## ADR-006: English only for all docs and code (2026-03)
+
+**Decision**: All documentation, code comments, and commit messages in English.
+
+**Rationale**: Broader accessibility for international contributors. Translated from French in PR #91.

--- a/.ai/memory/tech-debt.md
+++ b/.ai/memory/tech-debt.md
@@ -1,0 +1,37 @@
+# Tech Debt
+
+> Known issues, shortcuts, and things to fix.
+> Add items with a date and link to the tracking issue when one exists.
+
+## Active Tech Debt
+
+### update-project.yml is oversized (2025-11)
+- **Issue**: #105
+- **Problem**: 302 lines, too many triggers, fails silently without project scope token.
+- **Impact**: Hard to maintain, difficult to debug failures.
+- **Fix**: Simplify triggers and split into focused workflows.
+
+### setup_project_fields.py is dead code (2025-11)
+- **Issue**: #103
+- **Problem**: GitHub API cannot create custom project fields programmatically. The script does nothing useful.
+- **Impact**: Confuses contributors, copied to template users unnecessarily.
+- **Fix**: Remove the script and its references in step 5.
+
+### Longtermhelp has token in git remote URL (2026-03)
+- **Problem**: Security risk -- token visible in `.git/config`.
+- **Impact**: Token could be leaked if config is shared.
+- **Fix**: Use credential helper or SSH instead.
+
+## Bash Pitfalls
+
+### `((VAR++))` fails under `set -e` when VAR=0
+- **Workaround**: Use `VAR=$((VAR+1))` instead.
+- **Affected files**: Any bash script using arithmetic increment.
+
+### zsh incompatibility with `declare -A`
+- **Workaround**: Use explicit variables instead of associative arrays.
+- **Affected**: Setup scripts that might run under zsh.
+
+## Resolved
+
+_Move items here when fixed, with the PR number._

--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ template/.setup/.setup-state.json
 site/
 
 # AI session state (local, not committed)
-.ai/
+.ai/session-state.md

--- a/scripts/update-memory.sh
+++ b/scripts/update-memory.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Update .ai/memory/current-sprint.md with data from GitHub
+# Usage: scripts/update-memory.sh
+# Uses GITHUB_TOKEN= to target dyvan account
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MEMORY_FILE="${REPO_ROOT}/.ai/memory/current-sprint.md"
+
+if [ ! -f "$MEMORY_FILE" ]; then
+    echo "Error: $MEMORY_FILE not found"
+    exit 1
+fi
+
+# Use GITHUB_TOKEN= to target dyvan account
+GH="gh"
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    GH="env GITHUB_TOKEN= gh"
+fi
+
+echo "Fetching data from GitHub..."
+
+# Get open issues count
+OPEN_COUNT=$(eval "$GH issue list --state open --json number --jq 'length'" 2>/dev/null || echo "?")
+
+# Get in-progress issues
+IN_PROGRESS=$(eval "$GH issue list --label 'status:in-progress' --json number,title --jq '.[] | \"- #\\(.number): \\(.title)\"'" 2>/dev/null || echo "_Could not fetch._")
+if [ -z "$IN_PROGRESS" ]; then
+    IN_PROGRESS="_No items in progress._"
+fi
+
+# Get in-review PRs
+IN_REVIEW=$(eval "$GH pr list --json number,title --jq '.[] | \"- #\\(.number): \\(.title)\"'" 2>/dev/null || echo "_Could not fetch._")
+if [ -z "$IN_REVIEW" ]; then
+    IN_REVIEW="_No items in review._"
+fi
+
+# Get ready issues (next up)
+NEXT_UP=$(eval "$GH issue list --label 'status:ready' --json number,title --jq '.[] | \"- #\\(.number): \\(.title)\"'" 2>/dev/null || echo "_Could not fetch._")
+if [ -z "$NEXT_UP" ]; then
+    NEXT_UP="_No items in Ready queue._"
+fi
+
+# Get recently closed issues (last 7 days)
+WEEK_AGO=$(date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
+if [ -n "$WEEK_AGO" ]; then
+    RECENTLY_CLOSED=$(eval "$GH issue list --state closed --json number,title,closedAt --jq '[.[] | select(.closedAt > \"$WEEK_AGO\")] | .[] | \"- #\\(.number): \\(.title)\"'" 2>/dev/null || echo "_Could not fetch._")
+else
+    RECENTLY_CLOSED="_Date calculation not supported on this platform._"
+fi
+if [ -z "$RECENTLY_CLOSED" ]; then
+    RECENTLY_CLOSED="_No items closed this week._"
+fi
+
+TODAY=$(date '+%Y-%m-%d')
+
+# Write updated file
+cat > "$MEMORY_FILE" << EOF
+# Current Sprint
+
+> Active work, priorities, and blockers.
+> Updated manually or via \`scripts/update-memory.sh\`.
+
+## Sprint Info
+
+- **Sprint**: (current)
+- **Open issues**: ${OPEN_COUNT}
+- **Last updated**: ${TODAY}
+
+## In Progress
+
+<!-- Items currently being worked on. Auto-populated by update-memory.sh -->
+
+${IN_PROGRESS}
+
+## Blockers
+
+<!-- Anything blocking progress -->
+
+_No blockers detected. Update manually if needed._
+
+## In Review
+
+<!-- PRs waiting for review -->
+
+${IN_REVIEW}
+
+## Next Up
+
+<!-- High-priority items from Ready queue -->
+
+${NEXT_UP}
+
+## Recently Completed
+
+<!-- Items closed this week -->
+
+${RECENTLY_CLOSED}
+EOF
+
+echo "Updated ${MEMORY_FILE}"
+echo "  Open issues: ${OPEN_COUNT}"
+echo "  Date: ${TODAY}"

--- a/template/.setup/steps/5-copy-files.sh
+++ b/template/.setup/steps/5-copy-files.sh
@@ -142,6 +142,32 @@ copy_claude_commands() {
     fi
 }
 
+copy_memory_templates() {
+    local src="${REPO_ROOT}/.ai/memory"
+    local dest="${PWD}/.ai/memory"
+
+    if [ "$REPO_ROOT" = "$PWD" ]; then
+        success "Memory templates already in place"
+        return 0
+    fi
+
+    if [ -d "$src" ]; then
+        mkdir -p "$dest"
+        local count=0
+        for tmpl in "$src"/*.md; do
+            if [ -f "$tmpl" ]; then
+                cp "$tmpl" "$dest/"
+                count=$((count+1))
+            fi
+        done
+        if [ $count -gt 0 ]; then
+            success "Copied $count memory templates to .ai/memory/"
+        fi
+    else
+        warning "No memory templates found at $src"
+    fi
+}
+
 copy_claude_md() {
     local src="${REPO_ROOT}/CLAUDE.md"
     local dest="${PWD}/CLAUDE.md"
@@ -177,6 +203,7 @@ run_step() {
     copy_scripts
     copy_claude_commands
     copy_claude_md
+    copy_memory_templates
 
     mark_step_completed "link_workflows"
     mark_step_completed "copy_claude_md"

--- a/tests/test_project_memory.py
+++ b/tests/test_project_memory.py
@@ -1,0 +1,121 @@
+"""Tests for project memory structure (.ai/memory/)."""
+
+import os
+import subprocess
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MEMORY_DIR = os.path.join(REPO_ROOT, ".ai", "memory")
+MEMORY_FILES = [
+    "architecture.md",
+    "decisions.md",
+    "conventions.md",
+    "current-sprint.md",
+    "tech-debt.md",
+]
+
+
+class TestMemoryFilesExist:
+    """All 5 memory files must exist."""
+
+    @pytest.mark.parametrize("filename", MEMORY_FILES)
+    def test_memory_file_exists(self, filename):
+        path = os.path.join(MEMORY_DIR, filename)
+        assert os.path.isfile(path), f"Missing memory file: {path}"
+
+
+class TestMemoryFileSize:
+    """Each memory file must be under 100 lines."""
+
+    @pytest.mark.parametrize("filename", MEMORY_FILES)
+    def test_memory_file_under_100_lines(self, filename):
+        path = os.path.join(MEMORY_DIR, filename)
+        with open(path) as f:
+            line_count = sum(1 for _ in f)
+        assert line_count <= 100, (
+            f"{filename} has {line_count} lines (max 100)"
+        )
+
+
+class TestMemoryFileHeading:
+    """Each memory file must have a title (# heading)."""
+
+    @pytest.mark.parametrize("filename", MEMORY_FILES)
+    def test_memory_file_has_heading(self, filename):
+        path = os.path.join(MEMORY_DIR, filename)
+        with open(path) as f:
+            first_line = f.readline().strip()
+        assert first_line.startswith("# "), (
+            f"{filename} first line is not a heading: {first_line!r}"
+        )
+
+
+class TestUpdateMemoryScript:
+    """update-memory.sh must exist and have valid bash syntax."""
+
+    def test_script_exists(self):
+        path = os.path.join(REPO_ROOT, "scripts", "update-memory.sh")
+        assert os.path.isfile(path), "scripts/update-memory.sh not found"
+
+    def test_script_is_executable(self):
+        path = os.path.join(REPO_ROOT, "scripts", "update-memory.sh")
+        assert os.access(path, os.X_OK), "scripts/update-memory.sh is not executable"
+
+    def test_script_valid_bash_syntax(self):
+        path = os.path.join(REPO_ROOT, "scripts", "update-memory.sh")
+        result = subprocess.run(
+            ["bash", "-n", path],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Bash syntax error in update-memory.sh: {result.stderr}"
+        )
+
+
+class TestStep5Integration:
+    """Step 5 must include copy_memory_templates."""
+
+    def test_step5_has_copy_memory_templates_function(self):
+        path = os.path.join(
+            REPO_ROOT, "template", ".setup", "steps", "5-copy-files.sh"
+        )
+        with open(path) as f:
+            content = f.read()
+        assert "copy_memory_templates" in content, (
+            "5-copy-files.sh missing copy_memory_templates function"
+        )
+
+    def test_step5_calls_copy_memory_templates_in_run_step(self):
+        path = os.path.join(
+            REPO_ROOT, "template", ".setup", "steps", "5-copy-files.sh"
+        )
+        with open(path) as f:
+            content = f.read()
+        # Must be called inside run_step(), not just defined
+        run_step_section = content[content.index("run_step()"):]
+        assert "copy_memory_templates" in run_step_section, (
+            "copy_memory_templates not called in run_step()"
+        )
+
+
+class TestGitignore:
+    """.gitignore must NOT ignore .ai/memory/."""
+
+    def test_gitignore_does_not_ignore_ai_memory(self):
+        path = os.path.join(REPO_ROOT, ".gitignore")
+        with open(path) as f:
+            lines = [line.strip() for line in f.readlines()]
+        # .ai/ would ignore everything under .ai including memory
+        assert ".ai/" not in lines, (
+            ".gitignore has '.ai/' which would ignore .ai/memory/"
+        )
+
+    def test_gitignore_ignores_session_state(self):
+        path = os.path.join(REPO_ROOT, ".gitignore")
+        with open(path) as f:
+            content = f.read()
+        assert ".ai/session-state.md" in content, (
+            ".gitignore should still ignore .ai/session-state.md"
+        )


### PR DESCRIPTION
## Summary

- Add `.ai/memory/` directory with 5 structured markdown files for persistent AI context: architecture, decisions, conventions, current-sprint, tech-debt
- Add `scripts/update-memory.sh` to auto-populate current-sprint.md from GitHub data
- Update `template/.setup/steps/5-copy-files.sh` with `copy_memory_templates()` so template users get memory files
- Update `.gitignore` to track `.ai/memory/` while keeping `.ai/session-state.md` ignored
- Add `tests/test_project_memory.py` with 22 tests (all passing)

Closes #98

## Test plan

- [x] All 22 pytest tests pass (`python3 -m pytest tests/test_project_memory.py -v`)
- [x] All 5 memory files exist, under 100 lines, with # heading
- [x] update-memory.sh is executable with valid bash syntax
- [x] Step 5 includes copy_memory_templates function and calls it in run_step()
- [x] .gitignore does not ignore .ai/memory/