### PR TITLE
feat: Add MCP GitHub server configuration (#108)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GH_TOKEN}"
+      }
+    }
+  }
+}

--- a/docs/mcp-github.md
+++ b/docs/mcp-github.md
@@ -1,0 +1,44 @@
+# MCP GitHub Server
+
+## What it provides
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) GitHub server
+gives Claude Code native access to GitHub APIs without shelling out to `gh`. This
+includes:
+
+- **Issues** -- list, create, update, comment
+- **Pull Requests** -- list, create, review, merge
+- **Repositories** -- search, read files, list branches
+- **Projects v2** -- read and update project board items
+
+## Configuration
+
+The server is configured in `.mcp.json` at the project root. It reads the
+`GH_TOKEN` environment variable from your `.env` file:
+
+```bash
+# .env (never commit this file)
+GH_TOKEN=ghp_xxxxxxxxxxxxx
+```
+
+No additional setup is needed. Claude Code detects `.mcp.json` automatically
+and starts the server on demand.
+
+## How it complements gh CLI
+
+| Capability           | gh CLI          | MCP GitHub        |
+|----------------------|-----------------|-------------------|
+| Shell scripting      | Native          | Not applicable    |
+| Structured API data  | JSON via --json | Native objects    |
+| Claude Code native   | Via Bash tool   | Direct tool calls |
+| Offline fallback     | Yes             | No                |
+
+Both approaches work. The MCP server provides a more integrated experience
+inside Claude Code, while `gh` CLI remains the fallback for scripting and
+when MCP is not available.
+
+## Troubleshooting
+
+- Ensure `GH_TOKEN` is set in `.env` with `repo`, `project`, and `read:org` scopes.
+- Run `npx @modelcontextprotocol/server-github` manually to verify the server starts.
+- If MCP is unavailable, all commands gracefully fall back to `gh` CLI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Hooks: hooks.md
       - Milestones: milestones.md
       - Wiki Templates: wiki.md
+      - MCP GitHub Server: mcp-github.md
   - Agents:
       - PM Agent: pm-agent.md
   - Contributing: Contributing.md

--- a/template/.setup/steps/5-copy-files.sh
+++ b/template/.setup/steps/5-copy-files.sh
@@ -198,6 +198,23 @@ copy_wiki_templates() {
     fi
 }
 
+copy_mcp_config() {
+    local src="${REPO_ROOT}/.mcp.json"
+    local dest="${PWD}/.mcp.json"
+
+    if [ "$REPO_ROOT" = "$PWD" ]; then
+        success "MCP config already in place"
+        return 0
+    fi
+
+    if [ -f "$src" ]; then
+        cp "$src" "$dest"
+        success "Copied .mcp.json to project root"
+    else
+        warning "No .mcp.json found at $src"
+    fi
+}
+
 copy_claude_md() {
     local src="${REPO_ROOT}/CLAUDE.md"
     local dest="${PWD}/CLAUDE.md"
@@ -235,6 +252,7 @@ run_step() {
     copy_claude_md
     copy_memory_templates
     copy_wiki_templates
+    copy_mcp_config
 
     mark_step_completed "link_workflows"
     mark_step_completed "copy_claude_md"

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,0 +1,89 @@
+"""Tests for MCP GitHub server configuration."""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+# Resolve project root (repo root, not tests/)
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestMcpJson:
+    """Validate .mcp.json exists and is correctly structured."""
+
+    @pytest.fixture(autouse=True)
+    def load_config(self):
+        self.config_path = os.path.join(PROJECT_ROOT, ".mcp.json")
+
+    def test_mcp_json_exists(self):
+        assert os.path.isfile(self.config_path), ".mcp.json must exist at project root"
+
+    def test_mcp_json_is_valid_json(self):
+        with open(self.config_path) as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+
+    def test_contains_github_server(self):
+        with open(self.config_path) as f:
+            data = json.load(f)
+        assert "mcpServers" in data, "Top-level key 'mcpServers' is required"
+        assert "github" in data["mcpServers"], "'github' server must be configured"
+
+    def test_github_server_command(self):
+        with open(self.config_path) as f:
+            data = json.load(f)
+        server = data["mcpServers"]["github"]
+        assert server.get("command") == "npx"
+        assert "@modelcontextprotocol/server-github" in server.get("args", [])
+
+    def test_token_uses_env_var(self):
+        """Token must reference an environment variable, not a hardcoded value."""
+        with open(self.config_path) as f:
+            data = json.load(f)
+        env = data["mcpServers"]["github"].get("env", {})
+        token_value = env.get("GITHUB_PERSONAL_ACCESS_TOKEN", "")
+        assert token_value.startswith("${"), (
+            "Token must use env var substitution (e.g. '${GH_TOKEN}'), "
+            f"got: '{token_value}'"
+        )
+
+
+class TestMcpDocs:
+    """Validate documentation for MCP GitHub server."""
+
+    def test_docs_file_exists(self):
+        docs_path = os.path.join(PROJECT_ROOT, "docs", "mcp-github.md")
+        assert os.path.isfile(docs_path), "docs/mcp-github.md must exist"
+
+    def test_docs_not_empty(self):
+        docs_path = os.path.join(PROJECT_ROOT, "docs", "mcp-github.md")
+        with open(docs_path) as f:
+            content = f.read()
+        assert len(content.strip()) > 100, "docs/mcp-github.md should have meaningful content"
+
+
+class TestStep5CopiesMcpConfig:
+    """Validate that step 5 includes .mcp.json in its copy logic."""
+
+    def test_step5_references_mcp(self):
+        step5_path = os.path.join(
+            PROJECT_ROOT, "template", ".setup", "steps", "5-copy-files.sh"
+        )
+        assert os.path.isfile(step5_path), "5-copy-files.sh must exist"
+        with open(step5_path) as f:
+            content = f.read()
+        assert "mcp" in content.lower(), (
+            "5-copy-files.sh must contain MCP copy logic"
+        )
+
+    def test_step5_copies_mcp_json(self):
+        step5_path = os.path.join(
+            PROJECT_ROOT, "template", ".setup", "steps", "5-copy-files.sh"
+        )
+        with open(step5_path) as f:
+            content = f.read()
+        assert ".mcp.json" in content, (
+            "5-copy-files.sh must reference .mcp.json"
+        )


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuring `@modelcontextprotocol/server-github` for native GitHub API access in Claude Code
- Add `docs/mcp-github.md` documenting what MCP provides, how to configure it, and how it complements `gh` CLI
- Update `mkdocs.yml` to include MCP docs in Reference nav section
- Add `copy_mcp_config()` function to `template/.setup/steps/5-copy-files.sh` so template users get the config
- Add `tests/test_mcp_config.py` with 9 tests covering config validity, token env var usage, docs, and step 5 integration

Closes #108

## Test plan
- [x] `python3 -m pytest tests/test_mcp_config.py -v` -- 9/9 pass
- [x] `python3 -m pytest tests/ -v` -- 187/187 pass (no regressions)