### PR TITLE
feat: add milestone-based sprint tracking (#110)

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -1,0 +1,47 @@
+# Milestones and Sprint Tracking
+
+GitHub Milestones group issues into time-boxed sprints with progress bars.
+
+## Sprint Naming Convention
+
+Format: **`Sprint N (YYYY-WNN)`** -- e.g. `Sprint 1 (2025-W12)` due 2025-03-21.
+
+## Creating a Sprint
+
+### With the helper script
+
+```bash
+./scripts/create-sprint.sh "Sprint 1 (2025-W12)" "2025-03-21"
+```
+
+The script reads `GH_OWNER`/`GH_REPO` from `.env`, or detects them via `gh repo view`.
+
+### Manually
+
+```bash
+GITHUB_TOKEN= gh api repos/{owner}/{repo}/milestones \
+  -f title="Sprint 1 (2025-W12)" -f due_on="2025-03-21T23:59:59Z"
+```
+
+## Assigning Issues to a Milestone
+
+```bash
+GITHUB_TOKEN= gh issue edit 123 --milestone "Sprint 1 (2025-W12)"
+```
+
+Or use the GitHub UI sidebar on any issue.
+
+## Integration with Slash Commands
+
+`/next-task` prioritises issues by milestone due-date so current-sprint
+tasks surface first. `/sprint-report` reads milestone progress to
+generate a summary.
+
+## Viewing Sprint Progress
+
+```bash
+GITHUB_TOKEN= gh api repos/{owner}/{repo}/milestones --jq \
+  '.[] | "\(.title): \(.open_issues) open, \(.closed_issues) closed"'
+```
+
+GitHub also shows a progress bar on each milestone page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,4 +84,5 @@ nav:
       - Troubleshooting: Troubleshooting.md
       - FAQ: faq.md
       - Hooks: hooks.md
+      - Milestones: milestones.md
   - Contributing: Contributing.md

--- a/scripts/create-sprint.sh
+++ b/scripts/create-sprint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Usage: ./scripts/create-sprint.sh "Sprint 1 (2025-W12)" "2025-03-21"
+# Creates a GitHub milestone for a sprint with the given title and due date.
+set -euo pipefail
+
+TITLE="${1:?Usage: create-sprint.sh <title> <due-date>}"
+DUE_DATE="${2:?Usage: create-sprint.sh <title> <due-date>}"
+
+# Load .env if available
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+# Resolve owner/repo from .env or gh CLI
+if [ -z "${GH_OWNER:-}" ] || [ -z "${GH_REPO:-}" ]; then
+  REPO_INFO=$(GITHUB_TOKEN= gh repo view --json owner,name -q '.owner.login + "/" + .name')
+  GH_OWNER="${REPO_INFO%%/*}"
+  GH_REPO="${REPO_INFO##*/}"
+fi
+
+echo "Creating milestone: $TITLE (due $DUE_DATE) in $GH_OWNER/$GH_REPO"
+
+GITHUB_TOKEN= gh api "repos/$GH_OWNER/$GH_REPO/milestones" \
+  -f title="$TITLE" \
+  -f due_on="${DUE_DATE}T23:59:59Z" \
+  -f state="open" \
+  --jq '"Milestone #\(.number) created: \(.title) (due \(.due_on))"'

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -1,0 +1,51 @@
+"""Tests for milestone / sprint tracking feature (#110)."""
+
+import os
+import subprocess
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_create_sprint_script_exists():
+    """The create-sprint.sh helper script must exist."""
+    path = os.path.join(REPO_ROOT, "scripts", "create-sprint.sh")
+    assert os.path.isfile(path), f"Missing {path}"
+
+
+def test_create_sprint_script_is_executable():
+    """The script must have the executable bit set."""
+    path = os.path.join(REPO_ROOT, "scripts", "create-sprint.sh")
+    assert os.access(path, os.X_OK), f"{path} is not executable"
+
+
+def test_create_sprint_script_valid_bash_syntax():
+    """The script must pass bash -n (syntax check)."""
+    path = os.path.join(REPO_ROOT, "scripts", "create-sprint.sh")
+    result = subprocess.run(
+        ["bash", "-n", path], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"Syntax error: {result.stderr}"
+
+
+def test_create_sprint_script_uses_github_token_pattern():
+    """The script must use the GITHUB_TOKEN= pattern for gh commands."""
+    path = os.path.join(REPO_ROOT, "scripts", "create-sprint.sh")
+    with open(path) as f:
+        content = f.read()
+    assert "GITHUB_TOKEN=" in content, (
+        "Script should use GITHUB_TOKEN= pattern for gh commands"
+    )
+
+
+def test_milestones_doc_exists():
+    """docs/milestones.md must exist."""
+    path = os.path.join(REPO_ROOT, "docs", "milestones.md")
+    assert os.path.isfile(path), f"Missing {path}"
+
+
+def test_milestones_doc_under_50_lines():
+    """docs/milestones.md must be under 50 lines."""
+    path = os.path.join(REPO_ROOT, "docs", "milestones.md")
+    with open(path) as f:
+        lines = f.readlines()
+    assert len(lines) <= 50, f"milestones.md has {len(lines)} lines (max 50)"


### PR DESCRIPTION
## Summary

- Add `scripts/create-sprint.sh` to create GitHub milestones for sprints
- Add `docs/milestones.md` documenting the milestone workflow and conventions
- Add `tests/test_milestones.py` with validation tests for the script and docs
- Update `mkdocs.yml` nav to include the milestones page

## Test plan

- [x] All 184 tests pass (`python3 -m pytest tests/ -v`)
- [x] `bash -n scripts/create-sprint.sh` passes (syntax check)
- [x] `docs/milestones.md` is under 50 lines
- [x] Script uses `GITHUB_TOKEN=` pattern

Closes #110