### PR TITLE
feat: add PM agent for sprint planning and backlog grooming (#109)

### DIFF
--- a/.claude/agents/pm-agent.md
+++ b/.claude/agents/pm-agent.md
@@ -1,0 +1,55 @@
+---
+name: pm-agent
+description: Project management agent for sprint planning, backlog grooming, retrospectives, and health checks
+allowed-tools: Bash(gh:*), Bash(GITHUB_TOKEN=:*), Bash(git:*), Bash(date:*), Read, Write, Grep, Glob
+---
+
+# Project Management Agent
+
+You are a PM agent for a GitHub-based project. You have access to the project board, issues, PRs, and milestones.
+
+## Capabilities
+
+### Sprint Planning
+When asked to plan a sprint:
+1. Check past velocity: count story points completed in last 2-4 weeks
+2. List "Ready" issues sorted by Priority (P0 > P1 > P2), then Milestone, then Effort
+3. Propose a sprint scope that fits the average velocity
+4. Show the proposed sprint as a table with issue #, title, priority, effort
+5. Ask for confirmation before assigning milestone
+
+### Backlog Grooming
+When asked to groom the backlog:
+1. Find issues without labels -- suggest labels
+2. Find issues without effort estimates -- suggest estimates
+3. Find stale issues (no activity > 30 days) -- suggest close or re-prioritize
+4. Find duplicate or overlapping issues -- suggest consolidation
+5. Output a grooming report
+
+### Retrospective
+When asked for a retrospective:
+1. List completed issues in the last sprint/milestone
+2. Calculate: velocity, avg time-to-merge, avg review time
+3. Identify: what went well (fast merges), what was slow (long PRs)
+4. List blockers encountered
+5. Suggest improvements
+
+### Health Check
+When asked for a health check:
+1. PRs open > 7 days without review
+2. Issues "In Progress" for > 5 days
+3. Branches with no recent commits
+4. CI failures on open PRs
+5. Issues without assignees
+6. Output a health report with action items
+
+## Project Board Context
+- Project ID: PVT_kwHOAX_dWc4BGnys
+- Status field: PVTSSF_lAHOAX_dWc4BGnyszg3nS_U (Backlog=f75ad846, Ready=61e4505c, In progress=47fc9ee4, In review=df73e18b, Done=98236657)
+- Priority field: PVTSSF_lAHOAX_dWc4BGnyszg3nTXs (P0=79628723, P1=0a877460, P2=da944a9c)
+- Effort field: PVTSSF_lAHOAX_dWc4BGnyszg4oAuc (1=08e40e54, 2=8296128d, 3=94ddd87f, 5=61b3d099, 8=02981c20)
+
+## Important
+- Use `GITHUB_TOKEN= gh ...` for all gh commands (dyvan account)
+- Output reports in clean markdown
+- Ask for confirmation before making changes (assigning milestones, closing issues, etc.)

--- a/docs/pm-agent.md
+++ b/docs/pm-agent.md
@@ -1,0 +1,37 @@
+# PM Agent
+
+The PM agent is a Claude Code custom agent for project management tasks.
+
+## Invoke
+
+In Claude Code, use the agent via `/agent pm-agent` followed by a prompt.
+
+## Capabilities
+
+| Command | What it does |
+|---------|-------------|
+| Sprint planning | Checks velocity, proposes a sprint scope from Ready issues |
+| Backlog grooming | Finds unlabeled, unestimated, stale, or duplicate issues |
+| Retrospective | Summarizes completed work, velocity, merge times, blockers |
+| Health check | Flags stale PRs, stuck issues, CI failures, unassigned work |
+
+## Examples
+
+```
+/agent pm-agent Plan the next sprint
+/agent pm-agent Groom the backlog
+/agent pm-agent Run a retrospective for the last 2 weeks
+/agent pm-agent Health check
+```
+
+## How it works
+
+The agent reads the project board via `gh` CLI (GraphQL) and outputs
+markdown reports. It asks for confirmation before making any changes
+(assigning milestones, closing issues, etc.).
+
+## Configuration
+
+The agent uses project board IDs defined in its source file at
+`.claude/agents/pm-agent.md`. Update those IDs if you use a different
+GitHub Projects board.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,4 +86,6 @@ nav:
       - FAQ: faq.md
       - Hooks: hooks.md
       - Milestones: milestones.md
+  - Agents:
+      - PM Agent: pm-agent.md
   - Contributing: Contributing.md

--- a/tests/test_pm_agent.py
+++ b/tests/test_pm_agent.py
@@ -1,0 +1,90 @@
+"""Tests for the PM agent definition file."""
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AGENT_PATH = os.path.join(REPO_ROOT, ".claude", "agents", "pm-agent.md")
+
+
+def _read_agent():
+    with open(AGENT_PATH) as f:
+        return f.read()
+
+
+class TestPmAgentExists:
+    def test_file_exists(self):
+        assert os.path.isfile(AGENT_PATH), f"Agent file not found at {AGENT_PATH}"
+
+
+class TestPmAgentFrontmatter:
+    def test_has_yaml_frontmatter(self):
+        content = _read_agent()
+        assert content.startswith("---"), "File must start with YAML frontmatter"
+        parts = content.split("---", 2)
+        assert len(parts) >= 3, "File must have closing --- for frontmatter"
+
+    def test_frontmatter_has_name(self):
+        content = _read_agent()
+        frontmatter = content.split("---", 2)[1]
+        assert "name:" in frontmatter
+
+    def test_frontmatter_has_description(self):
+        content = _read_agent()
+        frontmatter = content.split("---", 2)[1]
+        assert "description:" in frontmatter
+
+    def test_frontmatter_has_allowed_tools(self):
+        content = _read_agent()
+        frontmatter = content.split("---", 2)[1]
+        assert "allowed-tools:" in frontmatter
+
+
+class TestPmAgentSections:
+    def test_has_sprint_planning(self):
+        content = _read_agent()
+        assert "### Sprint Planning" in content
+
+    def test_has_backlog_grooming(self):
+        content = _read_agent()
+        assert "### Backlog Grooming" in content
+
+    def test_has_retrospective(self):
+        content = _read_agent()
+        assert "### Retrospective" in content
+
+    def test_has_health_check(self):
+        content = _read_agent()
+        assert "### Health Check" in content
+
+
+class TestPmAgentReferences:
+    def test_references_project_board_id(self):
+        content = _read_agent()
+        assert "PVT_kwHOAX_dWc4BGnys" in content
+
+    def test_references_status_field(self):
+        content = _read_agent()
+        assert "PVTSSF_lAHOAX_dWc4BGnyszg3nS_U" in content
+
+    def test_references_priority_field(self):
+        content = _read_agent()
+        assert "PVTSSF_lAHOAX_dWc4BGnyszg3nTXs" in content
+
+    def test_references_effort_field(self):
+        content = _read_agent()
+        assert "PVTSSF_lAHOAX_dWc4BGnyszg4oAuc" in content
+
+    def test_references_github_token_pattern(self):
+        content = _read_agent()
+        assert "GITHUB_TOKEN=" in content
+
+    def test_no_hardcoded_secrets(self):
+        content = _read_agent()
+        # Should not contain actual API keys or tokens
+        assert "ghp_" not in content
+        assert "gho_" not in content
+        assert "AIza" not in content
+        # Should not contain .env values
+        assert not re.search(r"GEMINI_API_KEY\s*=\s*\S+", content)
+        assert not re.search(r"GH_TOKEN\s*=\s*ghp_", content)


### PR DESCRIPTION
## Summary
- Add `.claude/agents/pm-agent.md` custom agent with sprint planning, backlog grooming, retrospective, and health check capabilities
- Add `tests/test_pm_agent.py` with 15 tests covering file existence, frontmatter, sections, references, and no hardcoded secrets
- Add `docs/pm-agent.md` documentation and update `mkdocs.yml` nav

Closes #109

## Test plan
- [x] `python3 -m pytest tests/test_pm_agent.py -v` -- 15/15 passed
- [x] Full test suite -- 193/193 passed