### PR TITLE
feat: make Gemini AI features opt-in (#94)

### DIFF
--- a/.github/workflows/code-review-agent.yml
+++ b/.github/workflows/code-review-agent.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
+    if: ${{ secrets.GEMINI_API_KEY != '' || secrets.GEMINI_REVIEW_API_KEY != '' }}
+
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_REVIEW_API_KEY || secrets.GEMINI_API_KEY }}
 
     steps:
       - name: Checkout code
@@ -45,31 +49,9 @@ jobs:
       - name: Run Code Review with Gemini
         id: review
         env:
-          # Specific key first, then generic fallback (for template users with a single key)
-          GEMINI_REVIEW_API_KEY: ${{ secrets.GEMINI_REVIEW_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Pick the right API key: specific > generic
-          API_KEY="${GEMINI_REVIEW_API_KEY:-$GEMINI_API_KEY}"
-
-          if [ -z "$API_KEY" ]; then
-            echo "No Gemini API key found, using basic review"
-            cat > /tmp/review_comment.md <<'BASIC'
-          **Code Review (Basic Mode)**
-
-          > Full AI review requires a `GEMINI_API_KEY` or `GEMINI_REVIEW_API_KEY` secret.
-
-          Basic checks to perform manually:
-          - [ ] No syntax errors
-          - [ ] No debug statements left
-          - [ ] Commit messages follow conventions
-          - [ ] No secrets or credentials committed
-          BASIC
-            exit 0
-          fi
-
           python3 - <<'PYEOF'
           import os, sys, json, requests
 
@@ -85,7 +67,7 @@ jobs:
 
           pr_title = os.getenv("PR_TITLE", "")
           pr_body = os.getenv("PR_BODY", "")
-          api_key = os.getenv("GEMINI_REVIEW_API_KEY") or os.getenv("GEMINI_API_KEY")
+          api_key = os.getenv("GEMINI_API_KEY")
 
           prompt = f"""Review this GitHub Pull Request. Provide constructive feedback in GitHub-friendly Markdown.
 
@@ -150,3 +132,12 @@ jobs:
           gh pr comment $PR_NUMBER \
             --repo "$REPO" \
             --body "Warning: Code review workflow encountered an error. Please check the workflow logs."
+
+  skip-notice:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.GEMINI_API_KEY == '' && secrets.GEMINI_REVIEW_API_KEY == '' }}
+    steps:
+      - name: AI code review skipped
+        run: |
+          echo "AI code review skipped -- no Gemini API key configured."
+          echo "To enable, add GEMINI_API_KEY (or GEMINI_REVIEW_API_KEY) to repository secrets."

--- a/.github/workflows/generate-specification.yml
+++ b/.github/workflows/generate-specification.yml
@@ -18,12 +18,14 @@ jobs:
   generate-specification:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'issues' && github.event.label.name == 'generate-specification') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'issues' && github.event.label.name == 'generate-specification') ||
+      github.event_name == 'workflow_dispatch') &&
+      (secrets.GEMINI_API_KEY != '' || secrets.GEMINI_SPEC_API_KEY != '')
 
     env:
       GH_OWNER: ${{ github.repository_owner }}
       GH_REPO: ${{ github.event.repository.name }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_SPEC_API_KEY || secrets.GEMINI_API_KEY }}
 
     steps:
       - name: Checkout code
@@ -49,22 +51,9 @@ jobs:
           echo "number=${ISSUE_NUM}" >> $GITHUB_OUTPUT
           echo "📋 Processing issue #${ISSUE_NUM}"
 
-      - name: Check for Gemini API key
-        run: |
-          if [ -n "${{ secrets.GEMINI_SPEC_API_KEY }}" ]; then
-            echo "✅ Using GEMINI_SPEC_API_KEY"
-          elif [ -n "${{ secrets.GEMINI_API_KEY }}" ]; then
-            echo "✅ Using GEMINI_API_KEY (fallback)"
-          else
-            echo "❌ No Gemini API key found"
-            echo "   Set GEMINI_API_KEY or GEMINI_SPEC_API_KEY in repository secrets"
-            exit 1
-          fi
-
       - name: Generate specification
         id: generate
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_SPEC_API_KEY || secrets.GEMINI_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "🤖 Generating detailed specification from QCM responses..."
@@ -101,3 +90,15 @@ jobs:
         run: |
           echo "❌ Specification generation failed"
           echo "Check the logs above for details"
+
+  skip-notice:
+    runs-on: ubuntu-latest
+    if: |
+      ((github.event_name == 'issues' && github.event.label.name == 'generate-specification') ||
+      github.event_name == 'workflow_dispatch') &&
+      secrets.GEMINI_API_KEY == '' && secrets.GEMINI_SPEC_API_KEY == ''
+    steps:
+      - name: AI specification generation skipped
+        run: |
+          echo "AI specification generation skipped -- no Gemini API key configured."
+          echo "To enable, add GEMINI_API_KEY (or GEMINI_SPEC_API_KEY) to repository secrets."

--- a/.github/workflows/plan-with-gemini.yml
+++ b/.github/workflows/plan-with-gemini.yml
@@ -17,14 +17,16 @@ permissions:
 jobs:
   generate-qcm:
     runs-on: ubuntu-latest
-    # Only run if the label is "plan-with-gemini" or if manually triggered
+    # Only run if the label is "plan-with-gemini" or if manually triggered, AND a Gemini key exists
     if: |
-      (github.event_name == 'issues' && github.event.label.name == 'plan-with-gemini') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'issues' && github.event.label.name == 'plan-with-gemini') ||
+      github.event_name == 'workflow_dispatch') &&
+      (secrets.GEMINI_API_KEY != '' || secrets.GEMINI_PLAN_API_KEY != '')
 
     env:
       GH_OWNER: ${{ github.repository_owner }}
       GH_REPO: ${{ github.event.repository.name }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_PLAN_API_KEY || secrets.GEMINI_API_KEY }}
 
     steps:
       - name: Checkout code
@@ -60,23 +62,7 @@ jobs:
           echo "number=${ISSUE_NUM}" >> $GITHUB_OUTPUT
           echo "📋 Processing issue #${ISSUE_NUM}"
 
-      - name: Check for Gemini API key
-        run: |
-          # Specific key first, then generic fallback
-          if [ -n "${{ secrets.GEMINI_PLAN_API_KEY }}" ]; then
-            echo "✅ Using GEMINI_PLAN_API_KEY"
-          elif [ -n "${{ secrets.GEMINI_API_KEY }}" ]; then
-            echo "✅ Using GEMINI_API_KEY (fallback)"
-          else
-            echo "❌ No Gemini API key found"
-            echo "   Set GEMINI_API_KEY or GEMINI_PLAN_API_KEY in repository secrets"
-            echo "   Get your key at: https://ai.google.dev/gemini-api/docs/api-key"
-            exit 1
-          fi
-
       - name: Generate and post QCM
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_PLAN_API_KEY || secrets.GEMINI_API_KEY }}
         run: |
           echo "🤖 Generating QCM using Gemini AI..."
           python scripts/generate_qcm.py \
@@ -106,3 +92,15 @@ jobs:
           echo "   Issue: #${{ steps.issue.outputs.number }}"
           echo "   Status: ${{ job.status }}"
           echo "   Trigger: ${{ github.event_name }}"
+
+  skip-notice:
+    runs-on: ubuntu-latest
+    if: |
+      ((github.event_name == 'issues' && github.event.label.name == 'plan-with-gemini') ||
+      github.event_name == 'workflow_dispatch') &&
+      secrets.GEMINI_API_KEY == '' && secrets.GEMINI_PLAN_API_KEY == ''
+    steps:
+      - name: AI planning skipped
+        run: |
+          echo "AI planning skipped -- no Gemini API key configured."
+          echo "To enable, add GEMINI_API_KEY (or GEMINI_PLAN_API_KEY) to repository secrets."

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -1,0 +1,42 @@
+# AI Features (Gemini)
+
+This project includes optional AI-powered workflows using Google Gemini.
+All AI features are **opt-in** and skip cleanly when no API key is configured.
+
+## Workflows Using Gemini
+
+| Workflow | Trigger | What It Does |
+|----------|---------|--------------|
+| `code-review-agent.yml` | PR opened/synced | Posts an AI code review comment on the PR |
+| `plan-with-gemini.yml` | Label `plan-with-gemini` | Generates a specification questionnaire (QCM) on the issue |
+| `generate-specification.yml` | Label `generate-specification` | Generates a detailed specification from QCM answers |
+
+## Behavior Without a Key
+
+When no Gemini API key is configured, each workflow:
+
+- Skips the main job entirely (neutral exit, no failure)
+- Logs a message: *"AI ... skipped -- no Gemini API key configured."*
+- Does **not** block PRs or issue workflows
+
+No action is required to disable AI features -- they are off by default.
+
+## How to Enable
+
+1. Get a Gemini API key at <https://ai.google.dev/gemini-api/docs/api-key>
+2. Add it as a repository secret named `GEMINI_API_KEY`
+   (**Settings > Secrets and variables > Actions**)
+3. AI workflows will activate automatically on the next trigger
+
+## Per-Workflow Keys (Optional)
+
+You can override the key for individual workflows:
+
+| Secret | Used By |
+|--------|---------|
+| `GEMINI_REVIEW_API_KEY` | `code-review-agent.yml` |
+| `GEMINI_PLAN_API_KEY` | `plan-with-gemini.yml` |
+| `GEMINI_SPEC_API_KEY` | `generate-specification.yml` |
+
+Each workflow falls back to `GEMINI_API_KEY` if its specific key is not set.
+Only `GEMINI_API_KEY` is required; per-workflow keys are optional overrides.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
   - User Guide:
       - Using the Template: Using-The-Template.md
       - Configuration: Configuration.md
+      - AI Features: ai-features.md
       - QCM Specification: QCM-Specification.md
       - Scripts Reference: Scripts-Reference.md
   - Architecture:

--- a/tests/test_gemini_opt_in.py
+++ b/tests/test_gemini_opt_in.py
@@ -1,0 +1,77 @@
+"""
+Tests that Gemini AI workflows are opt-in and skip cleanly without API keys.
+"""
+
+import os
+import yaml
+import pytest
+
+WORKFLOW_DIR = os.path.join(os.path.dirname(__file__), "..", ".github", "workflows")
+
+GEMINI_WORKFLOWS = {
+    "code-review-agent.yml": "GEMINI_REVIEW_API_KEY",
+    "plan-with-gemini.yml": "GEMINI_PLAN_API_KEY",
+    "generate-specification.yml": "GEMINI_SPEC_API_KEY",
+}
+
+
+def load_workflow(filename):
+    path = os.path.join(WORKFLOW_DIR, filename)
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def read_workflow_raw(filename):
+    path = os.path.join(WORKFLOW_DIR, filename)
+    with open(path) as f:
+        return f.read()
+
+
+class TestGeminiWorkflowsExist:
+    """All three Gemini workflows must be present."""
+
+    @pytest.mark.parametrize("filename", GEMINI_WORKFLOWS.keys())
+    def test_workflow_file_exists(self, filename):
+        path = os.path.join(WORKFLOW_DIR, filename)
+        assert os.path.isfile(path), f"Workflow {filename} not found"
+
+
+class TestGeminiOptInMechanism:
+    """Each workflow must check for secrets.GEMINI_API_KEY to skip when absent."""
+
+    @pytest.mark.parametrize("filename", GEMINI_WORKFLOWS.keys())
+    def test_has_secrets_check(self, filename):
+        raw = read_workflow_raw(filename)
+        assert "secrets.GEMINI_API_KEY" in raw, (
+            f"{filename} must reference secrets.GEMINI_API_KEY for opt-in gating"
+        )
+
+    @pytest.mark.parametrize("filename,specific_key", GEMINI_WORKFLOWS.items())
+    def test_has_specific_key_check(self, filename, specific_key):
+        raw = read_workflow_raw(filename)
+        assert f"secrets.{specific_key}" in raw, (
+            f"{filename} must reference secrets.{specific_key}"
+        )
+
+
+class TestGeminiFallbackPattern:
+    """Each workflow must use the fallback pattern: SPECIFIC_KEY || GEMINI_API_KEY."""
+
+    @pytest.mark.parametrize("filename,specific_key", GEMINI_WORKFLOWS.items())
+    def test_uses_fallback_pattern(self, filename, specific_key):
+        raw = read_workflow_raw(filename)
+        pattern = f"secrets.{specific_key} || secrets.GEMINI_API_KEY"
+        assert pattern in raw, (
+            f"{filename} must use fallback pattern: {pattern}"
+        )
+
+
+class TestGeminiSkipNotice:
+    """Each workflow should have a skip-notice job for when no key is set."""
+
+    @pytest.mark.parametrize("filename", GEMINI_WORKFLOWS.keys())
+    def test_has_skip_notice_job(self, filename):
+        data = load_workflow(filename)
+        assert "skip-notice" in data.get("jobs", {}), (
+            f"{filename} must have a 'skip-notice' job for graceful skipping"
+        )


### PR DESCRIPTION
## Summary

- All 3 Gemini workflows (`code-review-agent`, `plan-with-gemini`, `generate-specification`) now skip cleanly when no API key is configured
- Each workflow uses a job-level `if` condition checking for `secrets.GEMINI_API_KEY` (or its per-workflow override)
- Each workflow includes a `skip-notice` job that logs a neutral message when keys are absent
- Fallback pattern (`GEMINI_*_API_KEY || GEMINI_API_KEY`) set at job-level `env` instead of per-step
- Removed redundant manual key-check steps from `plan-with-gemini.yml` and `generate-specification.yml`
- Added `docs/ai-features.md` documenting which features use Gemini and how to enable them
- Added `mkdocs.yml` nav entry for the new doc
- Added `tests/test_gemini_opt_in.py` with 15 tests covering existence, opt-in gating, fallback pattern, and skip-notice jobs

Closes #94

## Test plan

- [x] `python3 -m pytest tests/test_gemini_opt_in.py -v` -- 15/15 passed
- [x] `python3 -m pytest tests/ -v` -- 193/193 passed (no regressions)
- [ ] Verify workflows skip cleanly on a repo without GEMINI_API_KEY configured