### PR TITLE
feat: add wiki templates for shared knowledge base (#111)

### DIFF
--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -1,0 +1,34 @@
+# Wiki Templates
+
+The template includes starter pages for your GitHub Wiki, providing a shared knowledge base for human developers and AI tools.
+
+## Enabling the Wiki
+
+1. Go to your repo **Settings > Features** and check **Wikis**
+2. Create one initial page via the GitHub UI (this initializes the wiki git repo)
+
+## Initializing Wiki Pages
+
+```bash
+./scripts/init-wiki.sh
+```
+
+This clones your wiki repo, copies the template pages, and pushes them. Existing pages are not overwritten.
+
+## Included Pages
+
+| Page | Purpose |
+|------|---------|
+| `Home.md` | Project overview and quick links |
+| `Architecture.md` | System design, components, data flow |
+| `Decisions.md` | Architecture Decision Records (ADR log) |
+| `Conventions.md` | Code style, naming, git workflow |
+| `Onboarding.md` | Setup guide for new contributors |
+
+## How AI Tools Use the Wiki
+
+AI assistants can read wiki pages to understand project context. **Architecture** clarifies component boundaries, **Decisions** explains rationale, and **Conventions** ensures generated code matches project style. Keep pages concise and current.
+
+## Customization
+
+Edit templates in `template/wiki/` before running `init-wiki.sh`, or edit pages directly in the GitHub Wiki UI after initialization.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - FAQ: faq.md
       - Hooks: hooks.md
       - Milestones: milestones.md
+      - Wiki Templates: wiki.md
   - Agents:
       - PM Agent: pm-agent.md
   - Contributing: Contributing.md

--- a/scripts/init-wiki.sh
+++ b/scripts/init-wiki.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Initialize GitHub Wiki with starter templates
+#
+# Usage: ./scripts/init-wiki.sh
+#
+# Clones the wiki repo, copies template pages, commits and pushes.
+# Prerequisites:
+#   - Wiki must be enabled on the repo (Settings > Features > Wiki)
+#   - Create at least one page via the GitHub UI first (initializes the wiki repo)
+#   - Git push access to the wiki repo
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WIKI_TEMPLATES="${REPO_ROOT}/template/wiki"
+
+# Detect repo owner/name from git remote
+REMOTE_URL=$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null || true)
+if [ -z "$REMOTE_URL" ]; then
+    echo "Error: no git remote 'origin' found"
+    exit 1
+fi
+
+# Extract owner/repo from SSH or HTTPS URL
+OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+if [ -z "$OWNER_REPO" ]; then
+    echo "Error: could not parse owner/repo from remote URL"
+    exit 1
+fi
+
+WIKI_URL="https://github.com/${OWNER_REPO}.wiki.git"
+TMPDIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "Cloning wiki for ${OWNER_REPO}..."
+if ! git clone "$WIKI_URL" "$TMPDIR/wiki" 2>/dev/null; then
+    echo "Error: could not clone wiki. Make sure:"
+    echo "  1. Wiki is enabled in repo Settings > Features > Wiki"
+    echo "  2. You have created at least one page via the GitHub UI"
+    exit 1
+fi
+
+if [ ! -d "$WIKI_TEMPLATES" ]; then
+    echo "Error: wiki templates not found at ${WIKI_TEMPLATES}"
+    exit 1
+fi
+
+echo "Copying wiki templates..."
+COUNT=0
+for tmpl in "$WIKI_TEMPLATES"/*.md; do
+    if [ -f "$tmpl" ]; then
+        BASENAME=$(basename "$tmpl")
+        if [ -f "$TMPDIR/wiki/$BASENAME" ]; then
+            echo "  Skipping $BASENAME (already exists)"
+        else
+            cp "$tmpl" "$TMPDIR/wiki/$BASENAME"
+            echo "  Added $BASENAME"
+            COUNT=$((COUNT + 1))
+        fi
+    fi
+done
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "No new pages to add. Wiki is already up to date."
+    exit 0
+fi
+
+cd "$TMPDIR/wiki"
+git add -A
+git commit -m "Initialize wiki with starter templates"
+git push
+
+echo "Done. Pushed ${COUNT} wiki page(s) to ${OWNER_REPO}."

--- a/template/.setup/steps/5-copy-files.sh
+++ b/template/.setup/steps/5-copy-files.sh
@@ -172,6 +172,32 @@ copy_memory_templates() {
     fi
 }
 
+copy_wiki_templates() {
+    local src="${TEMPLATE_ROOT}/wiki"
+    local dest="${PWD}/template/wiki"
+
+    if [ "$REPO_ROOT" = "$PWD" ]; then
+        success "Wiki templates already in place"
+        return 0
+    fi
+
+    if [ -d "$src" ]; then
+        mkdir -p "$dest"
+        local count=0
+        for tmpl in "$src"/*.md; do
+            if [ -f "$tmpl" ]; then
+                cp "$tmpl" "$dest/"
+                count=$((count+1))
+            fi
+        done
+        if [ $count -gt 0 ]; then
+            success "Copied $count wiki templates to template/wiki/"
+        fi
+    else
+        warning "No wiki templates found at $src"
+    fi
+}
+
 copy_claude_md() {
     local src="${REPO_ROOT}/CLAUDE.md"
     local dest="${PWD}/CLAUDE.md"
@@ -208,6 +234,7 @@ run_step() {
     copy_claude_commands
     copy_claude_md
     copy_memory_templates
+    copy_wiki_templates
 
     mark_step_completed "link_workflows"
     mark_step_completed "copy_claude_md"

--- a/template/wiki/Architecture.md
+++ b/template/wiki/Architecture.md
@@ -1,0 +1,77 @@
+# Architecture
+
+## Overview
+
+<!-- Brief description of the system and its purpose -->
+
+This document describes the high-level architecture of the project.
+
+## Components
+
+<!-- List major components/services and their responsibilities -->
+
+| Component | Responsibility | Tech Stack |
+|-----------|---------------|------------|
+| Frontend  | User interface | TBD |
+| Backend   | Business logic and API | TBD |
+| Database  | Data persistence | TBD |
+| CI/CD     | Build, test, deploy | GitHub Actions |
+
+## Data Flow
+
+<!-- Describe how data moves through the system -->
+
+```
+User -> Frontend -> Backend API -> Database
+                 -> External Services
+```
+
+## Directory Structure
+
+```
+project-root/
+  src/           # Application source code
+  tests/         # Test suites
+  scripts/       # Automation scripts
+  docs/          # Documentation
+  .github/       # Workflows and templates
+```
+
+## External Dependencies
+
+<!-- List key external services, APIs, or libraries -->
+
+| Dependency | Purpose | Documentation |
+|-----------|---------|---------------|
+| TBD | TBD | TBD |
+
+## Deployment
+
+<!-- Describe how the system is deployed -->
+
+- **Environments**: development, staging, production
+- **Platform**: TBD
+- **Deploy process**: TBD
+
+## Diagrams
+
+<!-- Add Mermaid diagrams or links to architecture diagrams -->
+
+```mermaid
+graph LR
+    A[Client] --> B[API Gateway]
+    B --> C[Service]
+    C --> D[Database]
+```
+
+## Key Constraints
+
+<!-- List architectural constraints and trade-offs -->
+
+- Constraint 1: TBD
+- Constraint 2: TBD
+
+## Related Pages
+
+- [Decisions](Decisions) -- why we chose this architecture
+- [Conventions](Conventions) -- coding standards

--- a/template/wiki/Conventions.md
+++ b/template/wiki/Conventions.md
@@ -1,0 +1,66 @@
+# Conventions
+
+## Code Style
+
+<!-- Define language-specific style rules -->
+
+- Use the project's linter and formatter configuration
+- Run `npm run lint` / `python -m flake8` before committing
+- Keep functions short and focused (< 50 lines preferred)
+- Write descriptive variable and function names
+
+## Naming Patterns
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Files | kebab-case | `user-service.ts` |
+| Classes | PascalCase | `UserService` |
+| Functions | camelCase / snake_case | `getUser` / `get_user` |
+| Constants | UPPER_SNAKE | `MAX_RETRIES` |
+| Database tables | snake_case, plural | `user_accounts` |
+
+## Git Conventions
+
+### Branch Naming
+
+- Features: `feat/{issue-number}-{short-description}`
+- Bug fixes: `fix/{issue-number}-{short-description}`
+- Documentation: `docs/{issue-number}-{short-description}`
+- Refactoring: `refactor/{issue-number}-{short-description}`
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description (#issue-number)
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`
+
+### Pull Request Standards
+
+- Reference the issue: `Closes #123`
+- Keep PRs focused on one change
+- Include a description of what and why
+- Add test plan or testing notes
+- Respond to review comments before merging
+
+## Testing
+
+- Write tests for new features and bug fixes
+- Target > 80% code coverage
+- Name tests descriptively: `test_user_login_with_invalid_password_fails`
+- Keep unit tests fast (< 1s each)
+
+## Documentation
+
+- Update docs when changing public APIs or behavior
+- Keep wiki pages under 80 lines
+- Use code examples where helpful
+
+## Related Pages
+
+- [Architecture](Architecture) -- system design
+- [Decisions](Decisions) -- why we chose these conventions
+- [Onboarding](Onboarding) -- getting started

--- a/template/wiki/Decisions.md
+++ b/template/wiki/Decisions.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records
+
+This page tracks key architectural and technical decisions using the ADR format.
+
+## Template
+
+When adding a new decision, copy this template:
+
+```markdown
+### ADR-NNN: Title
+
+- **Date**: YYYY-MM-DD
+- **Status**: Proposed | Accepted | Deprecated | Superseded by ADR-NNN
+- **Context**: What is the issue or question?
+- **Decision**: What did we decide?
+- **Consequences**: What are the trade-offs?
+```
+
+## Decisions
+
+### ADR-001: Use GitHub Projects v2 for task tracking
+
+- **Date**: 2025-01-01
+- **Status**: Accepted
+- **Context**: We need a lightweight project management tool integrated with our codebase.
+- **Decision**: Use GitHub Projects v2 with custom fields (Status, Priority, Effort, Type).
+- **Consequences**: Tight integration with issues/PRs. Limited reporting compared to Jira. Free.
+
+### ADR-002: Conventional Commits for commit messages
+
+- **Date**: 2025-01-01
+- **Status**: Accepted
+- **Context**: We need consistent commit messages for changelogs and automation.
+- **Decision**: Follow the Conventional Commits specification (feat, fix, docs, etc.).
+- **Consequences**: Enables automated changelog generation. Requires team discipline.
+
+---
+
+<!-- Add new ADRs above this line -->
+
+## How to Add a Decision
+
+1. Copy the template above
+2. Assign the next ADR number
+3. Fill in all fields
+4. Set status to "Proposed" for team discussion, or "Accepted" if already agreed
+5. Update status when decisions change (Deprecated, Superseded)
+
+## Related Pages
+
+- [Architecture](Architecture) -- current system design
+- [Conventions](Conventions) -- coding standards

--- a/template/wiki/Home.md
+++ b/template/wiki/Home.md
@@ -1,0 +1,43 @@
+# Project Name
+
+Welcome to the project wiki. This is the shared knowledge base for both human developers and AI tools.
+
+## Quick Start
+
+1. Clone the repo: `git clone <repo-url>`
+2. Install dependencies: see [Onboarding](Onboarding)
+3. Read the [Conventions](Conventions) before contributing
+
+## Key Pages
+
+| Page | Description |
+|------|-------------|
+| [Architecture](Architecture) | System design, components, data flow |
+| [Decisions](Decisions) | Architecture Decision Records (ADRs) |
+| [Conventions](Conventions) | Code style, naming, git workflow |
+| [Onboarding](Onboarding) | Setup guide for new contributors |
+
+## Project Links
+
+- **Issue Tracker**: [Issues](../../issues)
+- **Project Board**: [Board](../../projects)
+- **CI/CD**: [Actions](../../actions)
+- **Documentation**: [Docs](../../pages) (if deployed)
+
+## How AI Tools Use This Wiki
+
+AI assistants (Claude, Gemini, Copilot) can read wiki pages to understand:
+
+- Project architecture and component boundaries
+- Naming conventions and code style
+- Past decisions and their rationale
+- Current sprint priorities
+
+Keep wiki pages concise and up to date so AI tools have accurate context.
+
+## Contributing to the Wiki
+
+- Keep pages under 80 lines for readability
+- Use clear headings and tables
+- Update pages when architecture or conventions change
+- Link between pages using `[Page Name](Page-Name)` syntax

--- a/template/wiki/Onboarding.md
+++ b/template/wiki/Onboarding.md
@@ -1,0 +1,78 @@
+# Onboarding
+
+Welcome! This guide helps new contributors (human or AI) get started quickly.
+
+## Prerequisites
+
+- Git installed and configured
+- GitHub CLI (`gh`) authenticated
+- Language runtime installed (see project README)
+- Editor with linter/formatter configured
+
+## Setup Steps
+
+1. **Clone the repository**
+   ```bash
+   git clone <repo-url>
+   cd <repo-name>
+   ```
+
+2. **Install dependencies**
+   ```bash
+   # See README.md for project-specific commands
+   ```
+
+3. **Verify setup**
+   ```bash
+   # Run tests to confirm everything works
+   ```
+
+4. **Read key documentation**
+   - [Architecture](Architecture) -- understand the system
+   - [Conventions](Conventions) -- learn the code style
+   - [Decisions](Decisions) -- understand past choices
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Project overview and setup instructions |
+| `CLAUDE.md` | Instructions for AI assistants |
+| `CONTRIBUTING.md` | Contribution guidelines |
+| `.github/workflows/` | CI/CD pipeline definitions |
+| `.ai/memory/` | Persistent AI context files |
+
+## Useful Commands
+
+```bash
+# Check project status
+gh issue list --label "status:in-progress"
+
+# Run tests
+# (project-specific command here)
+
+# Create a feature branch
+gh issue edit <number> --add-label "auto-branch"
+
+# Open a pull request
+gh pr create --title "feat: description (#issue)" --body "Closes #issue"
+```
+
+## Your First Contribution
+
+1. Pick an issue labeled `good-first-issue`
+2. Read the issue description and acceptance criteria
+3. Create a branch and make your changes
+4. Run tests and linters locally
+5. Open a PR referencing the issue
+
+## Getting Help
+
+- Comment on the issue if you have questions
+- Check [Troubleshooting](../../docs/Troubleshooting.md) for common problems
+- Review the [FAQ](../../docs/faq.md)
+
+## Related Pages
+
+- [Conventions](Conventions) -- coding standards
+- [Architecture](Architecture) -- system design

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,0 +1,105 @@
+"""
+Tests for wiki templates, init script, and documentation.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+WIKI_DIR = REPO_ROOT / "template" / "wiki"
+INIT_SCRIPT = REPO_ROOT / "scripts" / "init-wiki.sh"
+WIKI_DOC = REPO_ROOT / "docs" / "wiki.md"
+COPY_STEP = REPO_ROOT / "template" / ".setup" / "steps" / "5-copy-files.sh"
+
+EXPECTED_WIKI_PAGES = [
+    "Home.md",
+    "Architecture.md",
+    "Decisions.md",
+    "Conventions.md",
+    "Onboarding.md",
+]
+
+
+class TestWikiTemplates:
+    """Verify wiki template files exist and meet quality standards."""
+
+    @pytest.mark.parametrize("filename", EXPECTED_WIKI_PAGES)
+    def test_wiki_template_exists(self, filename):
+        """Each expected wiki template file must exist."""
+        path = WIKI_DIR / filename
+        assert path.exists(), f"Wiki template {filename} not found at {path}"
+
+    @pytest.mark.parametrize("filename", EXPECTED_WIKI_PAGES)
+    def test_wiki_template_under_80_lines(self, filename):
+        """Each wiki template must be under 80 lines."""
+        path = WIKI_DIR / filename
+        lines = path.read_text().splitlines()
+        assert len(lines) < 80, (
+            f"{filename} has {len(lines)} lines, expected < 80"
+        )
+
+    @pytest.mark.parametrize("filename", EXPECTED_WIKI_PAGES)
+    def test_wiki_template_has_heading(self, filename):
+        """Each wiki template must start with a # heading."""
+        path = WIKI_DIR / filename
+        content = path.read_text()
+        assert content.startswith("# "), (
+            f"{filename} does not start with a # heading"
+        )
+
+
+class TestInitWikiScript:
+    """Verify the init-wiki.sh script exists and has valid syntax."""
+
+    def test_init_script_exists(self):
+        assert INIT_SCRIPT.exists(), f"init-wiki.sh not found at {INIT_SCRIPT}"
+
+    def test_init_script_is_executable(self):
+        assert INIT_SCRIPT.stat().st_mode & 0o111, (
+            "init-wiki.sh is not executable"
+        )
+
+    def test_init_script_valid_bash_syntax(self):
+        """Check bash syntax with bash -n."""
+        result = subprocess.run(
+            ["bash", "-n", str(INIT_SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Bash syntax error in init-wiki.sh: {result.stderr}"
+        )
+
+
+class TestWikiDocumentation:
+    """Verify docs/wiki.md exists and is concise."""
+
+    def test_wiki_doc_exists(self):
+        assert WIKI_DOC.exists(), f"docs/wiki.md not found at {WIKI_DOC}"
+
+    def test_wiki_doc_under_40_lines(self):
+        lines = WIKI_DOC.read_text().splitlines()
+        assert len(lines) < 40, (
+            f"docs/wiki.md has {len(lines)} lines, expected < 40"
+        )
+
+
+class TestStep5CopiesWikiTemplates:
+    """Verify step 5 includes wiki template copying."""
+
+    def test_copy_wiki_templates_function_exists(self):
+        content = COPY_STEP.read_text()
+        assert "copy_wiki_templates" in content, (
+            "copy_wiki_templates function not found in 5-copy-files.sh"
+        )
+
+    def test_copy_wiki_templates_called_in_run_step(self):
+        content = COPY_STEP.read_text()
+        # Find the run_step function and check it calls copy_wiki_templates
+        run_step_start = content.index("run_step()")
+        run_step_body = content[run_step_start:]
+        assert "copy_wiki_templates" in run_step_body, (
+            "copy_wiki_templates is not called in run_step()"
+        )


### PR DESCRIPTION
## Summary
- Add 5 wiki template pages in `template/wiki/` (Home, Architecture, Decisions, Conventions, Onboarding)
- Add `scripts/init-wiki.sh` to push templates to a repo's GitHub Wiki
- Add `copy_wiki_templates()` to step 5 of setup for template distribution
- Add `docs/wiki.md` documentation and update mkdocs.yml nav
- Add `tests/test_wiki.py` with 22 tests covering all deliverables

Closes #111

## Test plan
- [x] All 200 tests pass (`python3 -m pytest tests/ -v`)
- [x] Wiki templates are under 80 lines each with proper headings
- [x] `init-wiki.sh` has valid bash syntax and is executable
- [x] `docs/wiki.md` is under 40 lines
- [x] Step 5 calls `copy_wiki_templates` in `run_step()`