### PR TITLE
docs: redesign landing page (#129)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ hide:
   font-size: 1.25em;
   color: #94a3b8;
   margin-bottom: 2.5em;
-  max-width: 620px;
+  max-width: 680px;
   margin-left: auto;
   margin-right: auto;
   line-height: 1.7;
@@ -202,7 +202,7 @@ hide:
   line-height: 1.6;
 }
 
-/* ── Section headings (all wrappers) ── */
+/* ── Section headings ── */
 .landing-section h2,
 .comparison-wrap h2,
 .workflow-wrap h2,
@@ -224,7 +224,7 @@ hide:
 /* ── Section wrappers ── */
 .landing-section {
   padding: 3em 2em;
-  max-width: 1000px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
@@ -282,12 +282,18 @@ hide:
   position: relative;
   z-index: 1;
 }
-.feature-icon.icon-board    { background: linear-gradient(135deg, #6366f1, #818cf8); }
-.feature-icon.icon-branch   { background: linear-gradient(135deg, #8b5cf6, #a78bfa); }
-.feature-icon.icon-spec     { background: linear-gradient(135deg, #6366f1, #a78bfa); }
-.feature-icon.icon-review   { background: linear-gradient(135deg, #7c3aed, #8b5cf6); }
-.feature-icon.icon-test     { background: linear-gradient(135deg, #4f46e5, #6366f1); }
-.feature-icon.icon-close    { background: linear-gradient(135deg, #6d28d9, #7c3aed); }
+.feature-icon.icon-commands  { background: linear-gradient(135deg, #6366f1, #818cf8); }
+.feature-icon.icon-agent     { background: linear-gradient(135deg, #8b5cf6, #a78bfa); }
+.feature-icon.icon-board     { background: linear-gradient(135deg, #4f46e5, #6366f1); }
+.feature-icon.icon-review    { background: linear-gradient(135deg, #7c3aed, #8b5cf6); }
+.feature-icon.icon-branch    { background: linear-gradient(135deg, #6d28d9, #7c3aed); }
+.feature-icon.icon-spec      { background: linear-gradient(135deg, #6366f1, #a78bfa); }
+.feature-icon.icon-memory    { background: linear-gradient(135deg, #059669, #10b981); }
+.feature-icon.icon-hooks     { background: linear-gradient(135deg, #d97706, #f59e0b); }
+.feature-icon.icon-plugin    { background: linear-gradient(135deg, #dc2626, #f87171); }
+.feature-icon.icon-close     { background: linear-gradient(135deg, #0891b2, #22d3ee); }
+.feature-icon.icon-test      { background: linear-gradient(135deg, #4338ca, #6366f1); }
+.feature-icon.icon-setup     { background: linear-gradient(135deg, #7c3aed, #a78bfa); }
 .feature-card h3 {
   font-size: 1.1em;
   font-weight: 700;
@@ -305,66 +311,72 @@ hide:
   z-index: 1;
 }
 
-/* ── Comparison Table ── */
-.comparison-wrap {
-  max-width: 820px;
+/* ── Command List ── */
+.commands-section {
+  max-width: 900px;
   margin: 0 auto;
   padding: 3em 2em;
 }
-.comparison-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(255,255,255,0.06);
+.commands-section h2 {
+  text-align: center;
+  font-size: 2.2em;
+  font-weight: 800;
+  margin-bottom: 0.2em;
+  color: var(--md-default-fg-color);
+  letter-spacing: -0.02em;
+}
+.commands-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1em;
   margin-top: 2em;
 }
-[data-md-color-scheme="default"] .comparison-table {
-  border: 1px solid #e2e8f0;
+.cmd-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 1em;
+  padding: 1.2em 1.4em;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.02);
+  transition: all 0.2s ease;
 }
-.comparison-table th {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(139, 92, 246, 0.1));
-  padding: 1em 1.3em;
-  font-weight: 700;
-  text-align: left;
-  font-size: 0.82em;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #818cf8;
-}
-[data-md-color-scheme="default"] .comparison-table th {
-  background: linear-gradient(135deg, #eef2ff, #ede9fe);
-  color: #4338ca;
-}
-.comparison-table td {
-  padding: 1em 1.3em;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
-  font-size: 0.92em;
-}
-[data-md-color-scheme="default"] .comparison-table td {
-  border-bottom: 1px solid #f1f5f9;
-}
-.comparison-table tr:last-child td { border-bottom: none; }
-.comparison-table tr:hover td {
+.cmd-card:hover {
+  border-color: rgba(129, 140, 248, 0.2);
   background: rgba(99, 102, 241, 0.04);
 }
-.comparison-table td:nth-child(3) {
-  color: #a78bfa;
-  font-weight: 600;
+[data-md-color-scheme="default"] .cmd-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
 }
-[data-md-color-scheme="default"] .comparison-table td:nth-child(3) {
-  color: #6d28d9;
+[data-md-color-scheme="default"] .cmd-card:hover {
+  border-color: #a5b4fc;
+  background: #f5f3ff;
+}
+.cmd-name {
+  font-family: var(--md-code-font);
+  font-size: 0.88em;
+  font-weight: 700;
+  color: #818cf8;
+  white-space: nowrap;
+  min-width: 130px;
+}
+[data-md-color-scheme="default"] .cmd-name {
+  color: #4f46e5;
+}
+.cmd-desc {
+  font-size: 0.88em;
+  color: var(--md-default-fg-color--light);
+  line-height: 1.5;
 }
 
-/* ── Workflow ── */
+/* ── Workflow Pipeline ── */
 .workflow-wrap {
   text-align: center;
   max-width: 1000px;
   margin: 0 auto;
   padding: 2em 2em 1em;
 }
-/* ── Pipeline ── */
 .pipeline-container {
   margin: 2.5em auto 1em;
   max-width: 520px;
@@ -484,6 +496,58 @@ hide:
   }
   .pipeline-group { max-width: 280px; }
   .pipeline-bridge { transform: rotate(90deg); padding: 0; }
+}
+
+/* ── Comparison Table ── */
+.comparison-wrap {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 3em 2em;
+}
+.comparison-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.06);
+  margin-top: 2em;
+}
+[data-md-color-scheme="default"] .comparison-table {
+  border: 1px solid #e2e8f0;
+}
+.comparison-table th {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(139, 92, 246, 0.1));
+  padding: 1em 1.3em;
+  font-weight: 700;
+  text-align: left;
+  font-size: 0.82em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #818cf8;
+}
+[data-md-color-scheme="default"] .comparison-table th {
+  background: linear-gradient(135deg, #eef2ff, #ede9fe);
+  color: #4338ca;
+}
+.comparison-table td {
+  padding: 1em 1.3em;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  font-size: 0.92em;
+}
+[data-md-color-scheme="default"] .comparison-table td {
+  border-bottom: 1px solid #f1f5f9;
+}
+.comparison-table tr:last-child td { border-bottom: none; }
+.comparison-table tr:hover td {
+  background: rgba(99, 102, 241, 0.04);
+}
+.comparison-table td:nth-child(3) {
+  color: #a78bfa;
+  font-weight: 600;
+}
+[data-md-color-scheme="default"] .comparison-table td:nth-child(3) {
+  color: #6d28d9;
 }
 
 /* ── Steps ── */
@@ -619,13 +683,14 @@ hide:
 /* ── Responsive ── */
 @media (max-width: 900px) {
   .features-grid, .steps-grid { grid-template-columns: 1fr; }
+  .commands-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 768px) {
   .hero-title { font-size: 2em; }
   .hero .subtitle { font-size: 1em; }
   .stat-card { padding: 1em 1.5em; }
   .stat-number { font-size: 2em; }
-  .landing-section h2, .comparison-wrap h2, .workflow-wrap h2, .faq-wrap h2, .footer-cta h2 { font-size: 1.6em; }
+  .landing-section h2, .comparison-wrap h2, .workflow-wrap h2, .commands-section h2, .faq-wrap h2, .footer-cta h2 { font-size: 1.6em; }
 }
 </style>
 
@@ -633,9 +698,9 @@ hide:
 
 <!-- Hero -->
 <div class="hero">
-<div class="hero-title">Automated GitHub<br>Project <span class="accent">Management</span></div>
+<div class="hero-title">AI-Powered GitHub<br>Project <span class="accent">Management</span></div>
 <p class="subtitle">
-You vibe your code with AI? This template handles everything else — issues, Kanban board, code reviews, branches. All automated. Zero config.
+Slash commands, a PM agent, Gemini workflows, and a full Kanban board -- all wired into your repo. You write code. The template handles everything else.
 </p>
 <div class="cta-row">
 <a href="Getting-Started/" class="btn-primary">Get Started</a>
@@ -647,15 +712,15 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 <div class="stats-bar">
 <div class="stat-card">
 <span class="stat-number">8</span>
+<span class="stat-label">Slash Commands</span>
+</div>
+<div class="stat-card">
+<span class="stat-number">9</span>
 <span class="stat-label">Workflows</span>
 </div>
 <div class="stat-card">
 <span class="stat-number">1</span>
 <span class="stat-label">Command Setup</span>
-</div>
-<div class="stat-card">
-<span class="stat-number">70%</span>
-<span class="stat-label">Automated</span>
 </div>
 <div class="stat-card">
 <span class="stat-number">0</span>
@@ -677,48 +742,76 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 
 </div>
 
-<!-- Features -->
+<!-- Core Features -->
 <div class="landing-section" markdown>
 
 ## What you get
 
-<p class="section-sub">Everything you need to run a project on GitHub, automated from day one.</p>
+<p class="section-sub">Slash commands, an AI agent, automated workflows, and plugin packaging -- all in one template.</p>
 
 <div class="features-grid">
 <div class="feature-card">
-<div class="feature-icon icon-board">
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+<div class="feature-icon icon-commands">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
 </div>
-<h3>Auto Project Board</h3>
-<p>Issues and PRs are automatically added to your Kanban board. Status flows from Backlog to Done without manual updates.</p>
-</div>
-<div class="feature-card">
-<div class="feature-icon icon-branch">
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
-</div>
-<h3>Automatic Branches</h3>
-<p>Add the <code>auto-branch</code> label to any issue. A branch <code>feat/123-title</code> is created and linked in seconds.</p>
+<h3>Slash Commands</h3>
+<p>Eight built-in commands for Claude Code: start tasks, finish PRs, plan sprints, pick the next task, save session context, and more.</p>
 </div>
 <div class="feature-card">
-<div class="feature-icon icon-spec">
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+<div class="feature-icon icon-agent">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.57-3.25 3.92"/><path d="M12 2a4 4 0 0 0-4 4c0 1.95 1.4 3.57 3.25 3.92"/><path d="M15.24 9.71a2 2 0 0 1 .76 1.58v.22a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2v-.22a2 2 0 0 1 .76-1.58"/><rect x="8" y="16" width="8" height="5" rx="1"/><path d="M12 13.5v2.5"/><path d="M8 18h8"/></svg>
 </div>
-<h3>Spec Questionnaire</h3>
-<p>Gemini generates a tailored questionnaire to clarify requirements before any code is written.</p>
+<h3>PM Agent</h3>
+<p>A dedicated project management agent that understands your board, priorities, milestones, and can orchestrate multi-step workflows autonomously.</p>
 </div>
 <div class="feature-card">
 <div class="feature-icon icon-review">
 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><line x1="9" y1="10" x2="15" y2="10"/></svg>
 </div>
 <h3>AI Code Review</h3>
-<p>Every PR is analyzed by Gemini AI with improvement suggestions, bug detection, and security checks.</p>
+<p>Every PR is analyzed by Gemini AI with improvement suggestions, bug detection, and security checks -- posted as a PR comment automatically.</p>
 </div>
 <div class="feature-card">
-<div class="feature-icon icon-test">
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+<div class="feature-icon icon-board">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
 </div>
-<h3>Automated Testing</h3>
-<p>Lint, tests, and build run on every PR. Results are posted as comments. No CI setup needed.</p>
+<h3>Auto Project Board</h3>
+<p>Issues and PRs flow through your Kanban board automatically. Status moves from Backlog to Done without any manual dragging.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-spec">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+</div>
+<h3>Spec Questionnaire</h3>
+<p>Gemini generates a tailored questionnaire to clarify requirements before any code is written. Answers feed into a detailed specification.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-branch">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+</div>
+<h3>Automatic Branches</h3>
+<p>Add the <code>auto-branch</code> label to any issue. A branch named <code>feat/123-title</code> is created and linked in seconds.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-memory">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><line x1="8" y1="7" x2="16" y2="7"/><line x1="8" y1="11" x2="13" y2="11"/></svg>
+</div>
+<h3>Project Memory</h3>
+<p>Persistent context stored in <code>.ai/memory/</code> survives between sessions. Decisions, architecture choices, and blockers are never forgotten.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-hooks">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+</div>
+<h3>Hooks</h3>
+<p>Lifecycle hooks let you inject custom logic at key moments -- before commits, after branch creation, on PR events. Fully extensible.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-plugin">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+</div>
+<h3>Plugin Packaging</h3>
+<p>Distribute as a Claude Code plugin via <code>.claude-plugin/</code>. Drop it into any repo to get the full PM toolkit instantly.</p>
 </div>
 <div class="feature-card">
 <div class="feature-icon icon-close">
@@ -726,6 +819,64 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 </div>
 <h3>Auto-close Features</h3>
 <p>Parent issues close automatically when all sub-issues are done. No manual tracking required.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-test">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+</div>
+<h3>CI/CD Out of the Box</h3>
+<p>Lint, tests, and build run on every PR. Results are posted as comments. Zero CI setup needed.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon icon-setup">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+</div>
+<h3>One-command Setup</h3>
+<p>A single <code>curl</code> command installs everything: labels, project board, workflows, scripts, and documentation. Idempotent and re-runnable.</p>
+</div>
+</div>
+
+</div>
+
+<!-- Slash Commands -->
+<div class="commands-section" markdown>
+
+## Slash commands for Claude Code
+
+<p class="section-sub">Type <code>/</code> in Claude Code to access project management directly from your terminal.</p>
+
+<div class="commands-grid">
+<div class="cmd-card">
+<span class="cmd-name">/start-task</span>
+<span class="cmd-desc">Pick an issue, create a branch, update the board to In Progress</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/finish-task</span>
+<span class="cmd-desc">Open a PR, move the issue to In Review</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/next-task</span>
+<span class="cmd-desc">Auto-pick the highest priority Ready task from the board</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/plan-task</span>
+<span class="cmd-desc">Break down a feature into estimated sub-tasks</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/task-status</span>
+<span class="cmd-desc">Show current task status, branch, and board state</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/sprint-report</span>
+<span class="cmd-desc">Generate a sprint progress report with velocity metrics</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/save-session</span>
+<span class="cmd-desc">Save session context to an issue comment for later</span>
+</div>
+<div class="cmd-card">
+<span class="cmd-name">/load-session</span>
+<span class="cmd-desc">Restore context from a previous session</span>
 </div>
 </div>
 
@@ -743,12 +894,14 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 <tr><th>Task</th><th>Without</th><th>With template</th></tr>
 </thead>
 <tbody>
-<tr><td>Create a branch</td><td>Manual <code>git checkout -b</code></td><td>Add label <code>auto-branch</code></td></tr>
+<tr><td>Start a task</td><td>Create branch, update board, assign</td><td><code>/start-task</code></td></tr>
 <tr><td>Track issue status</td><td>Drag cards on the board</td><td>Automatic: Backlog &rarr; Done</td></tr>
 <tr><td>Code review</td><td>Wait for humans</td><td>Gemini reviews in seconds</td></tr>
+<tr><td>Pick next task</td><td>Scan board, check priorities</td><td><code>/next-task</code></td></tr>
 <tr><td>Clarify requirements</td><td>Meetings, back-and-forth</td><td>Gemini generates a spec questionnaire</td></tr>
 <tr><td>Close parent issues</td><td>Remember to check manually</td><td>Auto-closes when sub-issues are done</td></tr>
-<tr><td>CI/CD setup</td><td>Write YAML from scratch</td><td>Pre-configured, works out of the box</td></tr>
+<tr><td>Sprint report</td><td>Spreadsheet or manual notes</td><td><code>/sprint-report</code></td></tr>
+<tr><td>Session context</td><td>Lost between sessions</td><td><code>/save-session</code> + <code>/load-session</code></td></tr>
 </tbody>
 </table>
 
@@ -764,23 +917,18 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 <div class="pipeline-group-border">
 <span class="pipeline-group-label manual-label">You</span>
 <div class="flow-card">
-<span class="flow-title">Create Issue</span>
-<span class="flow-desc">Describe the feature or bug</span>
+<span class="flow-title">/start-task</span>
+<span class="flow-desc">Pick an issue, branch is created</span>
 </div>
 <div class="flow-connector"><div class="dash"></div></div>
 <div class="flow-card">
-<span class="flow-title">Add Label</span>
-<span class="flow-desc">Trigger auto-branch</span>
-</div>
-<div class="flow-connector"><div class="dash"></div></div>
-<div class="flow-card">
-<span class="flow-title">Develop &amp; Push</span>
+<span class="flow-title">Develop & Push</span>
 <span class="flow-desc">Write code on your branch</span>
 </div>
 <div class="flow-connector"><div class="dash"></div></div>
 <div class="flow-card">
-<span class="flow-title">Open PR &amp; Merge</span>
-<span class="flow-desc">Review, approve, ship</span>
+<span class="flow-title">/finish-task</span>
+<span class="flow-desc">PR created, board updated</span>
 </div>
 </div>
 </div>
@@ -788,11 +936,6 @@ You vibe your code with AI? This template handles everything else — issues, Ka
 <div class="pipeline-group">
 <div class="pipeline-group-border auto-border">
 <span class="pipeline-group-label auto-label">Automated</span>
-<div class="flow-card">
-<span class="flow-title">Branch Created</span>
-<span class="flow-desc">feat/123-issue-title</span>
-</div>
-<div class="flow-connector"><div class="dash"></div></div>
 <div class="flow-card">
 <span class="flow-title">AI Code Review</span>
 <span class="flow-desc">Gemini analyzes your PR</span>
@@ -833,25 +976,25 @@ install.sh | bash
 </div>
 <div class="step-card" markdown>
 <span class="step-number">2</span>
-<h3>Create an issue</h3>
+<h3>Start a task</h3>
 
 ```bash
-gh issue create \
-  --title "Add auth" \
-  --label "type:feature"
-gh issue edit 1 \
-  --add-label "auto-branch"
+# In Claude Code, type:
+/start-task
+# Pick issue, branch is created,
+# board moves to In Progress
 ```
 
 </div>
 <div class="step-card" markdown>
 <span class="step-number">3</span>
-<h3>Open a PR</h3>
+<h3>Ship it</h3>
 
 ```bash
-gh pr create \
-  --title "feat: Add auth" \
-  --body "Closes #1"
+# When done, type:
+/finish-task
+# PR created, AI review runs,
+# issue auto-closes on merge
 ```
 
 </div>
@@ -865,10 +1008,13 @@ gh pr create \
 ## Frequently asked questions
 
 ??? question "Do I need a Gemini API key?"
-    It's optional. Without it you still get automatic branches, project board sync, CI tests, and auto-close. The Gemini key enables AI code review and specification questionnaires.
+    It's optional. Without it you still get automatic branches, project board sync, CI tests, slash commands, the PM agent, and auto-close. The Gemini key enables AI code review and specification questionnaires.
+
+??? question "What AI coding tools does this work with?"
+    The slash commands and PM agent are built for Claude Code, but the GitHub workflows and automation work with any tool -- Cursor, GitHub Copilot, Windsurf, or plain vim.
 
 ??? question "Can I use this with an existing repo?"
-    Yes. The install script creates a new project, but you can also copy the workflows and scripts into an existing repo manually.
+    Yes. The install script creates a new project, but you can also copy the workflows, commands, and scripts into an existing repo manually.
 
 ??? question "Is this only for Python projects?"
     No. The template works with any language. The Python scripts power the automation layer. Your project code can be anything.
@@ -876,8 +1022,11 @@ gh pr create \
 ??? question "What GitHub token scopes do I need?"
     The token needs `repo`, `project`, and `workflow` scopes. The setup wizard tells you exactly what to configure.
 
-??? question "What AI coding tools does this work with?"
-    All of them. Claude Code, Cursor, GitHub Copilot, Windsurf, or plain vim. The template handles project management — your coding tool handles the code.
+??? question "What is the PM Agent?"
+    A dedicated Claude Code agent (defined in `.claude/agents/pm-agent.md`) that understands your project board, priorities, and milestones. It can orchestrate multi-step project management workflows autonomously.
+
+??? question "How does project memory work?"
+    Session context and project decisions are stored in `.ai/memory/` and issue comments. Use `/save-session` before ending work and `/load-session` to pick up where you left off.
 
 </div>
 


### PR DESCRIPTION
Closes #129

## Summary

- Rewrote `docs/index.md` landing page to showcase all current features
- Added 12 feature cards covering: slash commands, PM agent, AI code review, auto project board, spec questionnaire, automatic branches, project memory, hooks, plugin packaging, auto-close features, CI/CD, and one-command setup
- Added a dedicated slash commands section with all 8 commands displayed in a grid
- Updated comparison table and workflow pipeline to use slash command terminology (`/start-task`, `/finish-task`)
- Updated stats bar: 8 Slash Commands, 9 Workflows, 1 Command Setup, 0 Config Needed
- Updated FAQ to cover PM agent, project memory, and tool compatibility
- All 256 tests pass