### PR TITLE
docs: fix stale references across documentation (#132)

### DIFF
--- a/.ai/memory/tech-debt.md
+++ b/.ai/memory/tech-debt.md
@@ -11,12 +11,6 @@
 - **Impact**: Hard to maintain, difficult to debug failures.
 - **Fix**: Simplify triggers and split into focused workflows.
 
-### setup_project_fields.py is dead code (2025-11)
-- **Issue**: #103
-- **Problem**: GitHub API cannot create custom project fields programmatically. The script does nothing useful.
-- **Impact**: Confuses contributors, copied to template users unnecessarily.
-- **Fix**: Remove the script and its references in step 5.
-
 ### Longtermhelp has token in git remote URL (2026-03)
 - **Problem**: Security risk -- token visible in `.git/config`.
 - **Impact**: Token could be leaked if config is shared.
@@ -34,4 +28,4 @@
 
 ## Resolved
 
-_Move items here when fixed, with the PR number._
+- **setup_project_fields.py** -- removed (dead code, #103)

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -203,7 +203,7 @@ Use this checklist when setting up a new project from this template:
 - [ ] **4. Manually configure Project Board custom fields**
   - Go to Project Settings → Fields
   - Add: Priority, Effort, Type, Status, Owner, Target Version
-  - See `PROJECT_BOARD_SETUP.md` for details
+  - See Project Settings in the GitHub UI for details
 
 - [ ] **5. Enable GitHub Pages** (if you want docs)
   - Go to Settings → Pages
@@ -429,7 +429,7 @@ python scripts/project_sync.py --issue 123 --status "In Progress"
 ## 📚 **Related Documentation**
 
 - `README.md`: Main project documentation
-- `claude.md`: Instructions for Gemini AI
+- `CLAUDE.md`: Instructions for Claude Code
 - `CONTRIBUTING.md`: Contribution guidelines
 - `.github/workflows/`: All automation workflows
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,59 +1,59 @@
-# ❓ Questions Fréquentes (FAQ)
+# ❓ Frequently Asked Questions (FAQ)
 
 ## Installation
 
-### Dois-je connaître la programmation ?
-Non ! Le template est conçu pour les non-développeurs. Suivez simplement le [Guide de démarrage](Getting-Started).
+### Do I need to know how to code?
+No! The template is designed for non-developers. Just follow the [Getting Started guide](Getting-Started).
 
-### Quels sont les prérequis ?
+### What are the prerequisites?
 - Git
 - GitHub CLI
 - Python 3.11+
 
-Tous s'installent facilement, voir [Getting Started](Getting-Started).
+All are easy to install, see [Getting Started](Getting-Started).
 
-### Combien de temps prend l'installation ?
-Environ 5 minutes en suivant le guide.
+### How long does installation take?
+About 5 minutes following the guide.
 
-## Utilisation
+## Usage
 
-### Comment créer une issue qui déclenche l'automation ?
+### How do I create an issue that triggers automation?
 ```bash
-gh issue create --title "Ma tâche" --label "type:feature,auto-branch"
+gh issue create --title "My task" --label "type:feature,auto-branch"
 ```
 
-### Puis-je désactiver Claude AI ?
-Oui, ne configurez simplement pas `CLAUDE_API_KEY`. La revue fonctionnera en mode basique.
+### Can I disable Gemini AI?
+Yes, simply don't configure `GEMINI_API_KEY`. The review will work in basic mode.
 
-### Comment personnaliser les labels ?
-Éditez `setup-project.sh` lignes 86+ et relancez le script.
+### How do I customize labels?
+Edit `template-setup.sh` and re-run the script.
 
-### Est-ce que ça fonctionne avec des repos privés ?
-Oui, complètement.
+### Does it work with private repos?
+Yes, fully.
 
-## Techniques
+## Technical
 
-### Quel modèle Claude est utilisé ?
-`claude-3-5-sonnet-20241022` par défaut. Modifiable dans `code-review-agent.yml`.
+### Which model is used?
+`gemini-2.0-flash` by default. Configurable in the workflow variables.
 
-### Puis-je utiliser un autre LLM ?
-Oui ! Remplacez l'appel API dans `code-review-agent.yml` par OpenAI, Gemini, etc.
+### Can I use a different LLM?
+Currently, all workflows use Gemini. To use a different provider, you need to modify the workflows manually.
 
-### Les workflows consomment-ils beaucoup de minutes GitHub Actions ?
-Non, très peu. Environ 1-2 minutes par workflow.
+### Do the workflows consume a lot of GitHub Actions minutes?
+No, very few. About 1-2 minutes per workflow.
 
-### Puis-je utiliser plusieurs projets ?
-Oui, spécifiez `--project NUMBER` dans les scripts.
+### Can I use multiple projects?
+Yes, specify `--project NUMBER` in the scripts.
 
-## Dépannage
+## Troubleshooting
 
 ### "Project not found"
-Vérifiez `.github/project.yml` et `gh project list --owner YOUR_USERNAME`.
+Check `.github/project.yml` and `gh project list --owner YOUR_USERNAME`.
 
-### Les workflows ne se déclenchent pas
-Vérifiez Settings → Actions → "Allow all actions".
+### Workflows not triggering
+Check Settings → Actions → "Allow all actions".
 
-### Plus de questions ?
+### More questions?
 - [Troubleshooting](Troubleshooting)
 - [Discussions](https://github.com/dyvan/github-project-llm-management/discussions)
 

--- a/docs/USER_EXPERIENCE_TEST_REPORT.md
+++ b/docs/USER_EXPERIENCE_TEST_REPORT.md
@@ -118,8 +118,8 @@ if not token:
     print("❌ GH_TOKEN or GITHUB_TOKEN environment variable not set")
     print("")
     print("💡 Need help? See:")
-    print("   - Troubleshooting: https://github.com/YOUR_REPO/wiki/Troubleshooting")
-    print("   - Getting Started: https://github.com/YOUR_REPO/wiki/Getting-Started")
+    print("   - Troubleshooting: https://dyvan.github.io/github-project-llm-management/Troubleshooting/")
+    print("   - Getting Started: https://dyvan.github.io/github-project-llm-management/getting-started/quickstart/")
     sys.exit(1)
 ```
 
@@ -147,7 +147,7 @@ cd your-project
 ./template-setup.sh
 ```
 
-➡️ **[Full guide in 5 steps](../../wiki/Getting-Started)**
+➡️ **[Full guide](https://dyvan.github.io/github-project-llm-management/getting-started/quickstart/)**
 ```
 
 **Priority**: 🟡 Medium

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -174,9 +174,6 @@ done
 
 ## 🔮 Future Scripts (Planned)
 
-- `generate_dashboard.py`: Generate project dashboard (DASHBOARD.md)
-- `velocity_calculator.py`: Calculate team velocity from completed story points
-- `claude_manager.py`: CLI interface for Claude to manage projects
 - `issue_templates_generator.py`: Bulk create issues from templates
 
 ---
@@ -217,9 +214,8 @@ gh issue close $TEST_ISSUE
 ## 📚 Related Documentation
 
 - `../AUTOMATION.md`: Complete automation guide
-- `../claude.md`: Instructions for Claude AI
+- `../CLAUDE.md`: Instructions for Claude Code
 - `../.github/workflows/update-project.yml`: Workflow using this script
-- `../PROJECT_BOARD_SETUP.md`: Project Board setup guide
 
 ---
 

--- a/template/README.md
+++ b/template/README.md
@@ -44,9 +44,7 @@ template/
 │   └── project-fields.json # Custom Project fields
 │
 ├── scripts/               # Optional utilities
-│   ├── project_sync.py
-│   ├── generate_dashboard.py
-│   └── velocity_calculator.py
+│   └── project_sync.py
 │
 ├── docs/                  # Template documentation
 │   ├── WORKFLOWS.md
@@ -212,22 +210,6 @@ Synchronizes the Project Board with issues/PRs:
 
 ```bash
 python3 scripts/project_sync.py --sync-all
-```
-
-### generate_dashboard.py
-
-Generates a progress dashboard:
-
-```bash
-python3 scripts/generate_dashboard.py --format json --output report.json
-```
-
-### velocity_calculator.py
-
-Calculates team velocity:
-
-```bash
-python3 scripts/velocity_calculator.py --weeks 4
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #132

Fixes stale references across all documentation files:

- **scripts/README.md**: Removed references to non-existent `generate_dashboard.py`, `velocity_calculator.py`, `claude_manager.py` from planned scripts. Fixed `claude.md` -> `CLAUDE.md` case. Removed dead link to `PROJECT_BOARD_SETUP.md`.
- **template/README.md**: Removed `generate_dashboard.py` and `velocity_calculator.py` from directory tree and utility scripts section (these scripts don't exist).
- **AUTOMATION.md**: Fixed `claude.md` -> `CLAUDE.md` case and label ("Instructions for Claude Code"). Replaced `PROJECT_BOARD_SETUP.md` reference with inline guidance.
- **docs/USER_EXPERIENCE_TEST_REPORT.md**: Replaced wiki links (`../../wiki/Getting-Started`, `wiki/Troubleshooting`) with MkDocs site URLs.
- **docs/FAQ.md**: Translated remaining French text to English (was missed in the original translation PR).
- **.ai/memory/tech-debt.md**: Moved `setup_project_fields.py` entry to Resolved (script was already removed).

## Test plan

- [x] `python3 -m pytest tests/ -v` -- 256 tests pass
- [x] No remaining references to removed files