### PR TITLE
fix: resolve E2E scenario 3 silent exit (#137)

### DIFF
--- a/.github/workflows/e2e-test-install.yml
+++ b/.github/workflows/e2e-test-install.yml
@@ -607,8 +607,8 @@ jobs:
           export GITHUB_TOKEN="$GH_TOKEN"
 
           echo "=== FIRST template-setup.sh run ==="
-          echo "y" | bash template-setup.sh --reset-state 2>&1 | tee /tmp/setup-run1.log
-          SETUP_EXIT=${PIPESTATUS[1]}
+          bash template-setup.sh --reset-state --yes 2>&1 | tee /tmp/setup-run1.log
+          SETUP_EXIT=${PIPESTATUS[0]}
           echo "exit_code=$SETUP_EXIT" >> $GITHUB_OUTPUT
 
           if [ $SETUP_EXIT -eq 0 ]; then
@@ -668,8 +668,8 @@ jobs:
           export GITHUB_TOKEN="$GH_TOKEN"
 
           echo "=== SECOND template-setup.sh run ==="
-          echo "y" | bash template-setup.sh 2>&1 | tee /tmp/setup-run2.log
-          SETUP_EXIT=${PIPESTATUS[1]}
+          bash template-setup.sh --yes 2>&1 | tee /tmp/setup-run2.log
+          SETUP_EXIT=${PIPESTATUS[0]}
           echo "exit_code=$SETUP_EXIT" >> $GITHUB_OUTPUT
 
           if [ $SETUP_EXIT -eq 0 ]; then

--- a/.github/workflows/e2e-test-template.yml
+++ b/.github/workflows/e2e-test-template.yml
@@ -137,9 +137,9 @@ jobs:
           # Override GITHUB_TOKEN so gh CLI uses our token
           export GITHUB_TOKEN="$GH_TOKEN"
 
-          # Run setup in non-interactive mode (pipe 'y' for confirmation)
-          echo "y" | bash template-setup.sh --reset-state 2>&1 | tee /tmp/setup.log
-          SETUP_EXIT=${PIPESTATUS[1]}
+          # Run setup in non-interactive mode
+          bash template-setup.sh --reset-state --yes 2>&1 | tee /tmp/setup.log
+          SETUP_EXIT=${PIPESTATUS[0]}
 
           echo "setup_exit=$SETUP_EXIT" >> $GITHUB_ENV
           echo "setup_exit=$SETUP_EXIT" >> $GITHUB_OUTPUT

--- a/template-setup.sh
+++ b/template-setup.sh
@@ -18,6 +18,9 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
+# Non-interactive mode (--yes / -y)
+YES_MODE=false
+
 # Safe read that works with piped stdin (tries /dev/tty first)
 safe_read() {
     local prompt="$1"
@@ -52,6 +55,7 @@ USAGE:
 
 OPTIONS:
   --help              Show this help
+  --yes, -y           Non-interactive mode (skip all prompts, use defaults)
   --skip-completed    Skip already done steps
   --dry-run           Preview changes without applying
   --reset-state       Start fresh (discard previous state)
@@ -75,11 +79,23 @@ EXAMPLES:
 EOF
 }
 
-# Check if --help requested
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-    show_help
-    exit 0
-fi
+# Parse flags before main
+PASS_THROUGH_ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        --yes|-y)
+            YES_MODE=true
+            ;;
+        *)
+            PASS_THROUGH_ARGS+=("$arg")
+            ;;
+    esac
+done
+set -- "${PASS_THROUGH_ARGS[@]}"
 
 # ============================================================================
 # Ensure .env exists (merged from bootstrap.sh)
@@ -112,6 +128,11 @@ ensure_env() {
     local gh_token="${GH_TOKEN:-}"
 
     if [ -z "$gh_token" ]; then
+        if [ "$YES_MODE" = true ]; then
+            echo -e "${RED}GH_TOKEN is required but --yes mode cannot prompt for it.${NC}"
+            echo "  Set GH_TOKEN in environment before using --yes."
+            return 1
+        fi
         echo -e "${BLUE}GitHub Personal Access Token (REQUIRED)${NC}"
         echo "  Used for: issues, labels, project board, workflows"
         echo "  Get one at: https://github.com/settings/tokens/new"
@@ -136,19 +157,24 @@ ensure_env() {
     local gemini_key="${GEMINI_API_KEY:-}"
 
     if [ -z "$gemini_key" ]; then
-        echo ""
-        echo -e "${BLUE}Google Gemini API Key (OPTIONAL - for AI features)${NC}"
-        echo "  Used for: QCM generation, specification generation, AI planning"
-        echo "  Get one at: https://aistudio.google.com/app/apikey"
-        echo "  If skipped: AI features will be disabled (add later if needed)"
-        echo ""
-        safe_read "Paste your GEMINI_API_KEY (or leave blank to skip): " gemini_key
-
-        if [ -z "$gemini_key" ]; then
-            echo "  Gemini API Key skipped - AI features will be disabled"
+        if [ "$YES_MODE" = true ]; then
+            echo "  Gemini API Key skipped (--yes mode) - AI features will be disabled"
             gemini_key="PLACEHOLDER_GEMINI_API_KEY_CHANGE_ME"
         else
-            echo -e "${GREEN}GEMINI_API_KEY configured${NC}"
+            echo ""
+            echo -e "${BLUE}Google Gemini API Key (OPTIONAL - for AI features)${NC}"
+            echo "  Used for: QCM generation, specification generation, AI planning"
+            echo "  Get one at: https://aistudio.google.com/app/apikey"
+            echo "  If skipped: AI features will be disabled (add later if needed)"
+            echo ""
+            safe_read "Paste your GEMINI_API_KEY (or leave blank to skip): " gemini_key
+
+            if [ -z "$gemini_key" ]; then
+                echo "  Gemini API Key skipped - AI features will be disabled"
+                gemini_key="PLACEHOLDER_GEMINI_API_KEY_CHANGE_ME"
+            else
+                echo -e "${GREEN}GEMINI_API_KEY configured${NC}"
+            fi
         fi
     else
         echo -e "${GREEN}GEMINI_API_KEY configured (from environment)${NC}"
@@ -226,7 +252,7 @@ validate_env() {
     if ! command -v gh &> /dev/null; then
         echo -e "${RED}❌ GitHub CLI (gh) not found${NC}"
         echo "   Install from: https://cli.github.com/"
-        ((errors++))
+        errors=$((errors + 1))
     else
         echo -e "${GREEN}✅ GitHub CLI${NC}"
     fi
@@ -235,7 +261,7 @@ validate_env() {
     if ! command -v python3 &> /dev/null; then
         echo -e "${RED}❌ Python 3 not found${NC}"
         echo "   Install Python 3.8 or higher"
-        ((errors++))
+        errors=$((errors + 1))
     else
         echo -e "${GREEN}✅ Python 3${NC}"
     fi
@@ -244,7 +270,7 @@ validate_env() {
     if ! command -v git &> /dev/null; then
         echo -e "${RED}❌ Git not found${NC}"
         echo "   Install from: https://git-scm.com/"
-        ((errors++))
+        errors=$((errors + 1))
     else
         echo -e "${GREEN}✅ Git${NC}"
     fi
@@ -254,7 +280,7 @@ validate_env() {
         if ! gh auth status &> /dev/null; then
             echo -e "${YELLOW}⚠️  GitHub CLI not authenticated${NC}"
             echo "   Run: gh auth login"
-            ((errors++))
+            errors=$((errors + 1))
         else
             echo -e "${GREEN}✅ GitHub authenticated${NC}"
         fi
@@ -365,12 +391,16 @@ main() {
     echo -e "${CYAN}Repository: $repo${NC}"
     echo ""
 
-    # Ask for confirmation
-    read -p "$(echo -e ${YELLOW})Continue setup for this repository? (y/n)$(echo -e ${NC}) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Setup cancelled."
-        exit 0
+    # Ask for confirmation (skip in non-interactive mode)
+    if [ "$YES_MODE" = true ]; then
+        echo -e "${GREEN}Auto-confirming setup (--yes mode)${NC}"
+    else
+        read -p "$(echo -e ${YELLOW})Continue setup for this repository? (y/n)$(echo -e ${NC}) " -n 1 -r || true
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Setup cancelled."
+            exit 0
+        fi
     fi
 
     echo ""

--- a/template/.setup/lib/github-api.sh
+++ b/template/.setup/lib/github-api.sh
@@ -29,16 +29,16 @@ create_labels() {
         # Check if label already exists using -F for fixed string matching (no regex)
         if gh label list "${repo_flag[@]}" --json name -q ".[].name" 2>/dev/null | grep -qF "$name"; then
             warning "Label '$name' already exists, skipping"
-            ((skipped++))
+            skipped=$((skipped + 1))
         else
             if gh label create "$name" --description "$description" --color "$color" "${repo_flag[@]}" > /dev/null 2>&1; then
                 success "Created label: $name"
-                ((count++))
+                count=$((count + 1))
             else
                 # If it fails, it might already exist - try with --force to update
                 if gh label create "$name" --description "$description" --color "$color" --force "${repo_flag[@]}" > /dev/null 2>&1; then
                     success "Updated label: $name"
-                    ((count++))
+                    count=$((count + 1))
                 else
                     error "Failed to create/update label: $name"
                 fi

--- a/template/.setup/steps/1-check-state.sh
+++ b/template/.setup/steps/1-check-state.sh
@@ -22,7 +22,7 @@ run_step() {
                 echo ""
                 info "Last completed at: $(jq -r '.setup_completed_at' "$STATE_FILE" 2>/dev/null)"
                 echo ""
-                read -p "Run setup again to verify/update? (y/n) " -n 1 -r
+                read -p "Run setup again to verify/update? (y/n) " -n 1 -r || true
                 echo
                 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                     return 0

--- a/template/.setup/steps/5-copy-files.sh
+++ b/template/.setup/steps/5-copy-files.sh
@@ -40,10 +40,10 @@ copy_workflows() {
     for wf in "${workflows[@]}"; do
         if [ -f "$src/$wf" ]; then
             cp "$src/$wf" "$dest/$wf"
-            ((count++))
+            count=$((count + 1))
         elif [ -f "${REPO_ROOT}/.github/workflows/$wf" ]; then
             cp "${REPO_ROOT}/.github/workflows/$wf" "$dest/$wf"
-            ((count++))
+            count=$((count + 1))
         fi
     done
 
@@ -111,7 +111,7 @@ copy_scripts() {
     for script in "${scripts[@]}"; do
         if [ -f "$src/$script" ]; then
             cp "$src/$script" "$dest/$script"
-            ((count++))
+            count=$((count + 1))
         fi
     done
 


### PR DESCRIPTION
## Summary
- Fix E2E scenario 3 (idempotency) failure where `template-setup.sh` exits silently with code 1
- Root cause: `echo "y" | bash template-setup.sh` — the single "y" from stdin was consumed by the GEMINI_API_KEY prompt in `ensure_env` (since `.env` doesn't exist yet in the template subdirectory). By the time the "Continue setup?" confirmation prompt at line 369 runs, stdin is at EOF. `read` returns exit code 1, and `set -e` kills the script.

## Changes
- **`template-setup.sh`**: Add `--yes`/`-y` flag for non-interactive mode (skips all prompts, uses env vars/defaults)
- **`template-setup.sh`**: Fix `((errors++))` → `errors=$((errors + 1))` to prevent `set -e` crash when errors=0
- **`template-setup.sh`**: Add `|| true` to `read` at confirmation prompt for EOF safety
- **`1-check-state.sh`**: Add `|| true` to `read` for EOF safety
- **`5-copy-files.sh`**: Fix `((count++))` → safe arithmetic
- **`github-api.sh`**: Fix `((count++))` and `((skipped++))` → safe arithmetic
- **E2E workflows**: Use `--yes` flag instead of piping `echo "y" |`, fix `PIPESTATUS` index (0 not 1)

## Test plan
- [ ] E2E scenario 3 (idempotency) passes in CI
- [ ] E2E template validation still passes
- [ ] Interactive mode still works (no `--yes` flag)

Closes #137